### PR TITLE
Add pcap_set_buffer_size() function with associated method

### DIFF
--- a/luomu-libpcap/examples/capture.rs
+++ b/luomu-libpcap/examples/capture.rs
@@ -8,6 +8,7 @@ fn main() -> Result<()> {
         .set_immediate(true)?
         .set_filter("udp")?
         .set_snaplen(65535)?
+        .set_buffer_size(512 * 1024)?
         .activate()?;
 
     for packet in pcap.capture() {

--- a/luomu-libpcap/src/functions.rs
+++ b/luomu-libpcap/src/functions.rs
@@ -38,6 +38,16 @@ pub fn pcap_close(pcap_t: &mut PcapT) {
     pcap_t.errbuf = Vec::new();
 }
 
+pub fn pcap_set_buffer_size(pcap_t: &PcapT, buffer_size: usize) -> Result<()> {
+    trace!("pcap_set_buffer_size({:p}, {})", pcap_t.pcap_t, buffer_size);
+    let ret = unsafe { libpcap::pcap_set_buffer_size(pcap_t.pcap_t, buffer_size as libc::c_int) };
+    match ret {
+        0 => Ok(()),
+        libpcap::PCAP_ERROR_ACTIVATED => Err(Error::AlreadyActivated),
+        n => panic!("Unknown return code {}", n),
+    }
+}
+
 pub fn pcap_set_promisc(pcap_t: &PcapT, promiscuous: bool) -> Result<()> {
     trace!("pcap_set_promisc({:p}, {})", pcap_t.pcap_t, promiscuous);
     let promisc = if promiscuous { 1 } else { 0 };

--- a/luomu-libpcap/src/lib.rs
+++ b/luomu-libpcap/src/lib.rs
@@ -89,6 +89,11 @@ pub struct PcapBuilder {
 }
 
 impl PcapBuilder {
+    pub fn set_buffer_size(self, buffer_size: usize) -> Result<PcapBuilder> {
+        pcap_set_buffer_size(&self.pcap_t, buffer_size)?;
+        Ok(self)
+    }
+
     pub fn set_promiscuous(self, promiscuous: bool) -> Result<PcapBuilder> {
         pcap_set_promisc(&self.pcap_t, promiscuous)?;
         Ok(self)


### PR DESCRIPTION
Add safe wrapper for `pcap_set_buffer_size()` PCAP function and add `PcapBuilder::set_buffer_size()` method.

These are used to set the PCAP's internal (ring) buffer size so that in high traffic burst situations we don't drop packets if we can't handle them fast enough.