### PR TITLE
Remove panics from Pcap error codes we don't recognize

### DIFF
--- a/luomu-libpcap/src/error.rs
+++ b/luomu-libpcap/src/error.rs
@@ -17,6 +17,8 @@ pub enum Error {
     PcapError(String),
     /// Warning from `libpcap`
     PcapWarning(String),
+    /// Unknown error code from `libpcap`.
+    PcapErrorCode(i32),
 }
 
 impl error::Error for Error {}
@@ -31,6 +33,7 @@ impl fmt::Display for Error {
             Error::CStringError(err) => err.fmt(f),
             Error::PcapError(err) => write!(f, "libpcap error: {}", err),
             Error::PcapWarning(warn) => write!(f, "libpcap warning: {}", warn),
+            Error::PcapErrorCode(code) => write!(f, "libpcap unknown error code: {}", code),
         }
     }
 }

--- a/luomu-libpcap/src/functions.rs
+++ b/luomu-libpcap/src/functions.rs
@@ -44,7 +44,7 @@ pub fn pcap_set_buffer_size(pcap_t: &PcapT, buffer_size: usize) -> Result<()> {
     match ret {
         0 => Ok(()),
         libpcap::PCAP_ERROR_ACTIVATED => Err(Error::AlreadyActivated),
-        n => panic!("Unknown return code {}", n),
+        n => Err(Error::PcapErrorCode(n)),
     }
 }
 
@@ -55,7 +55,7 @@ pub fn pcap_set_promisc(pcap_t: &PcapT, promiscuous: bool) -> Result<()> {
     match ret {
         0 => Ok(()),
         libpcap::PCAP_ERROR_ACTIVATED => Err(Error::AlreadyActivated),
-        n => panic!("Unknown return code {}", n),
+        n => Err(Error::PcapErrorCode(n)),
     }
 }
 
@@ -65,7 +65,7 @@ pub fn pcap_set_snaplen(pcap_t: &PcapT, snaplen: usize) -> Result<()> {
     match ret {
         0 => Ok(()),
         libpcap::PCAP_ERROR_ACTIVATED => Err(Error::AlreadyActivated),
-        n => panic!("Unknown return code {}", n),
+        n => Err(Error::PcapErrorCode(n)),
     }
 }
 
@@ -80,7 +80,7 @@ pub fn pcap_set_immediate_mode(pcap_t: &PcapT, immediate: bool) -> Result<()> {
     match ret {
         0 => Ok(()),
         libpcap::PCAP_ERROR_ACTIVATED => Err(Error::AlreadyActivated),
-        n => panic!("Unknown return code {}", n),
+        n => Err(Error::PcapErrorCode(n)),
     }
 }
 
@@ -170,7 +170,7 @@ pub fn pcap_next_ex<'p>(pcap_t: &PcapT) -> Result<Packet<'p>> {
         0 => return Err(Error::Timeout),
         -1 => return Err(get_error(pcap_t)?),
         -2 => return Err(Error::NoMorePackets),
-        n => panic!("Unknown return code {}", n),
+        n => return Err(Error::PcapErrorCode(n)),
     }
 
     if header.is_null() || packet.is_null() {


### PR DESCRIPTION
Panicing is bad, but so are undocumented errors from Pcap. Now it's up to user to handle these unknown errors. Its probably better than panicing.