### PR TITLE
Safety concerns

### DIFF
--- a/.github/workflows/rust_matrix.yml
+++ b/.github/workflows/rust_matrix.yml
@@ -12,7 +12,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.34.0  # MSRV
+          - 1.36.0  # MSRV
 
     steps:
       - uses: actions/checkout@v1

--- a/luomu-libpcap/src/functions.rs
+++ b/luomu-libpcap/src/functions.rs
@@ -36,11 +36,10 @@ pub fn pcap_create(source: &str) -> Result<PcapT> {
     Ok(PcapT { pcap_t, errbuf })
 }
 
-pub fn pcap_close(pcap_t: &mut PcapT) {
-    trace!("get_close({:p})", pcap_t.pcap_t);
-    unsafe { libpcap::pcap_close(pcap_t.pcap_t) }
-    pcap_t.pcap_t = std::ptr::null_mut();
-    pcap_t.errbuf = Vec::new();
+pub fn pcap_close(pcap_t: PcapT) {
+    trace!("pcap_close({:p})", pcap_t.pcap_t);
+    // PcapT is owned by this function and dropped at this point since it's no
+    // longer needed. Dropping frees the allocated resources.
 }
 
 pub fn pcap_set_buffer_size(pcap_t: &PcapT, buffer_size: usize) -> Result<()> {
@@ -147,10 +146,10 @@ pub fn pcap_setfilter(pcap_t: &PcapT, pcap_filter: &mut PcapFilter) -> Result<()
     check_pcap_error(pcap_t, ret)
 }
 
-pub fn pcap_freecode(pcap_filter: &mut PcapFilter) {
+pub fn pcap_freecode(pcap_filter: PcapFilter) {
     trace!("pcap_freecode({:p})", &pcap_filter.bpf_program);
-    unsafe { libpcap::pcap_freecode(&mut pcap_filter.bpf_program) };
-    pcap_filter.bpf_program = unsafe { std::mem::zeroed() };
+    // PcapFilter is owned by this function and dropped at this point since it's
+    // no longer needed. Dropping frees the allocated resources.
 }
 
 /// If data is needed, copy it before calling this again.
@@ -203,10 +202,10 @@ pub fn pcap_findalldevs() -> Result<PcapIfT> {
     }
 }
 
-pub fn pcap_freealldevs(pcap_if_t: &mut PcapIfT) {
+pub fn pcap_freealldevs(pcap_if_t: PcapIfT) {
     trace!("pcap_freealldevs({:p})", pcap_if_t.pcap_if_t);
-    unsafe { libpcap::pcap_freealldevs(pcap_if_t.pcap_if_t) };
-    pcap_if_t.pcap_if_t = std::ptr::null_mut();
+    // PcapIfT is owned by this function and dropped at this point since it's no
+    // longer needed. Dropping frees the allocated resources.
 }
 
 pub(crate) fn try_interface_from(pcap_if_t: *mut libpcap::pcap_if_t) -> Result<Interface> {

--- a/luomu-libpcap/src/lib.rs
+++ b/luomu-libpcap/src/lib.rs
@@ -32,7 +32,8 @@ impl PcapT {
 
 impl Drop for PcapT {
     fn drop(&mut self) {
-        pcap_close(self)
+        log::trace!("PcapT::drop({:p})", self.pcap_t);
+        unsafe { luomu_libpcap_sys::pcap_close(self.pcap_t) }
     }
 }
 
@@ -156,7 +157,8 @@ impl PcapFilter {
 
 impl Drop for PcapFilter {
     fn drop(&mut self) {
-        pcap_freecode(self)
+        log::trace!("PcapFilter::drop({:p})", &self.bpf_program);
+        unsafe { luomu_libpcap_sys::pcap_freecode(&mut self.bpf_program) }
     }
 }
 
@@ -310,7 +312,8 @@ impl PcapIfT {
 
 impl Drop for PcapIfT {
     fn drop(&mut self) {
-        pcap_freealldevs(self)
+        log::trace!("PcapIfT::drop({:?})", self.pcap_if_t);
+        unsafe { luomu_libpcap_sys::pcap_freealldevs(self.pcap_if_t) }
     }
 }
 


### PR DESCRIPTION
Improve safety on two places:

 1.  Move pcap_close(), pcap_freecode() and pcap_freealldevs() code to Drop

     Move the implementation of these function in appropriate Drop trait. Then this function can take the ownership of the struct in question and it's automatically dropped when function ends.

 2. Use MaybeUninit to manage uninitialized memory in pcap_compile
    
    We need to allocate memory for libpcap::bpf_program, but allocation leaves it in invalid state. We can wrap bpf_program in MaybeUninit until the contents are initialized by pcap_compile(). After we are sure pcap_compile() compiled the program we take the bpf_program out from MaybeUninit and can be certain it's properly defined.

Fixes #12