### PR TITLE
Set filter for Pcap directly instead of using the builder

### DIFF
--- a/luomu-libpcap/examples/capture.rs
+++ b/luomu-libpcap/examples/capture.rs
@@ -6,10 +6,11 @@ fn main() -> Result<()> {
     let pcap = Pcap::builder("en0")?
         .set_promiscuous(true)?
         .set_immediate(true)?
-        .set_filter("udp")?
         .set_snaplen(65535)?
         .set_buffer_size(512 * 1024)?
         .activate()?;
+
+    pcap.set_filter("udp")?;
 
     let mut count = 0;
     for packet in pcap.capture() {


### PR DESCRIPTION
Currently the Pcap filter is set with `PcapBuilder`, but it feels quirky because filter must be set after Pcap is activated. This PR removes setting the filter in` PcapBuilder` and now it must be set in `Pcap` struct directly. I also realized there's no need to store the Pcap filter anywhere. It's stated in documentation that the compiled filter can be freed after filter is set.