### PR TITLE
Add support for getting vlan tag and control information if it is stripped from packet

### DIFF
--- a/luomu-tpacketv3/src/if_packet.rs
+++ b/luomu-tpacketv3/src/if_packet.rs
@@ -43,7 +43,7 @@ pub struct tpacket_req3 {
 pub struct tpacket_hdr_variant1 {
     pub tp_rxhash: u32,
     pub tp_vlan_tci: u32,
-    pub tp_vlan_tpid: u32,
+    pub tp_vlan_tpid: u16,
     tp_padding: u16,
 }
 #[derive(Debug)]

--- a/luomu-tpacketv3/src/if_packet.rs
+++ b/luomu-tpacketv3/src/if_packet.rs
@@ -26,6 +26,8 @@ pub const PACKET_FLANOUT_FLAG_DEFRAG: libc::c_int = 0x800;
 
 pub const TP_STATUS_KERNEL: u32 = 0;
 pub const TP_STATUS_USER: u32 = 1;
+pub const TP_STATUS_VLAN_VALID: u32 = 1 << 4;
+pub const TP_STATUS_VLAN_TPID_VALID: u32 = 1 << 6;
 
 #[repr(C)]
 pub struct tpacket_req3 {

--- a/luomu-tpacketv3/src/ringbuf.rs
+++ b/luomu-tpacketv3/src/ringbuf.rs
@@ -27,6 +27,23 @@ impl<'a> PacketDescriptor<'a> {
         let data_ptr = unsafe { self.ptr.offset(self.hdr.tp_mac as isize) };
         unsafe { std::slice::from_raw_parts(data_ptr, self.hdr.tp_snaplen as usize) }
     }
+
+    pub fn has_vlan_tci(&self) -> bool {
+        (self.hdr.tp_status & if_packet::TP_STATUS_VLAN_VALID) == if_packet::TP_STATUS_VLAN_VALID
+    }
+
+    pub fn has_vlan_tpid(&self) -> bool {
+        (self.hdr.tp_status & if_packet::TP_STATUS_VLAN_TPID_VALID)
+            == if_packet::TP_STATUS_VLAN_TPID_VALID
+    }
+
+    pub fn get_vlan_tci(&self) -> u32 {
+        self.hdr.hv1.tp_vlan_tci
+    }
+
+    pub fn get_vlan_tpid(&self) -> u16 {
+        self.hdr.hv1.tp_vlan_tpid
+    }
 }
 
 impl<'a> From<*mut u8> for PacketDescriptor<'a> {


### PR DESCRIPTION
Vlan tags might or might not be present in the payload provided by tpacket API. If the are not in the data, they are provided in PacketDescriptor header and associated flags in the status flags are set. Add support for detecting this and providing the data with methods in `Packet` struct.. 

If the vlan information was provided by Packet Descriptor header and is no longer present in the actual packet payload, it can be read from `Packet` using `vlan_tpid()` and `vlan_tci()` methods. 