### PR TITLE
Add support for filtering packets with "pcap filter" in tpacketv3

### DIFF
--- a/luomu-libpcap/src/lib.rs
+++ b/luomu-libpcap/src/lib.rs
@@ -238,7 +238,7 @@ pub struct PcapFilter {
     bpf_program: libpcap::bpf_program,
 }
 
-impl PcapFilter {
+impl<'a> PcapFilter {
     /// compile a filter expression
     ///
     /// `compile()` is used to compile the filter into a filter program. See
@@ -257,6 +257,23 @@ impl PcapFilter {
     /// for the syntax of that string.
     pub fn compile_with_pcap_t(pcap_t: &PcapT, filter_str: &str) -> Result<PcapFilter> {
         pcap_compile(pcap_t, filter_str)
+    }
+
+    /// Get length of the compiled filter
+    pub fn get_raw_filter_len(&self) -> u32 {
+        self.bpf_program.bf_len
+    }
+
+    /// Get pointer to the raw compiled filter program.
+    /// Raw filter may be used when attaching filter to socket outside libpcap.
+    /// # Safety
+    /// Note that the pointer is valid only as long as this filter is valid.
+    /// The returned pointer will be cast as *void since there is no common
+    /// structure to which export the program.
+    pub unsafe fn get_raw_filter(&self) -> &std::ffi::c_void {
+        (self.bpf_program.bf_insns as *const std::ffi::c_void)
+            .as_ref()
+            .unwrap()
     }
 }
 

--- a/luomu-libpcap/src/lib.rs
+++ b/luomu-libpcap/src/lib.rs
@@ -238,7 +238,7 @@ pub struct PcapFilter {
     bpf_program: libpcap::bpf_program,
 }
 
-impl<'a> PcapFilter {
+impl PcapFilter {
     /// compile a filter expression
     ///
     /// `compile()` is used to compile the filter into a filter program. See

--- a/luomu-libpcap/tests/pcap-interfaces.rs
+++ b/luomu-libpcap/tests/pcap-interfaces.rs
@@ -1,6 +1,6 @@
 use std::net::IpAddr;
 
-use luomu_libpcap::{PcapIfT, Result};
+use luomu_libpcap::{PcapFilter, PcapIfT, Result};
 
 #[test]
 fn test_get_interfaces() -> Result<()> {
@@ -20,4 +20,19 @@ fn test_find_localhost() -> Result<()> {
     }
     assert!(false, "Couldn't find localhost");
     unreachable!("execution shouldn't get here")
+}
+
+#[test]
+fn test_compile_pcap_filter() -> Result<()> {
+    let filter = "host 10.0.0.1";
+    let _compiled = PcapFilter::compile(filter)?;
+    Ok(())
+}
+
+#[test]
+fn test_compile_invalid_pcap_filter() -> Result<()> {
+    let filter = "foo";
+    let res = PcapFilter::compile(filter);
+    assert!(res.is_err());
+    Ok(())
 }

--- a/luomu-tpacketv3/Cargo.toml
+++ b/luomu-tpacketv3/Cargo.toml
@@ -17,6 +17,7 @@ categories = [ "api-bindings", "network-programming" ]
 [dependencies]
 libc = "0.2"
 log = "0.4"
+luomu-libpcap = {path = "../luomu-libpcap/"}
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/luomu-tpacketv3/examples/demo.rs
+++ b/luomu-tpacketv3/examples/demo.rs
@@ -95,7 +95,7 @@ mod linux {
             params.block_count,
             params.block_size
         );
-        match tpacketv3::reader(interface, params) {
+        match tpacketv3::reader(interface, None, params) {
             Err(e) => warn!("Unable to create reader: {}", e),
             Ok(rd) => {
                 packet_producer(rd, ch, stop);


### PR DESCRIPTION
 * Add support for getting the raw compiled filter program from `PcapFilter` while trying to make sure the returned raw filter does not outlive `PcapFilter`
 * Add support for attaching bpf filter program to socket using `SO_ATTACH_FILTER` socket option in tpacketv3 wrapper
 * Change `tpacketv3::reader()` function to allow specifying pcap filter (with `Option<&str>`) to use.
 * This changes tpacketv3 to to require `luomu_libpcap` as build time dependency. 