### PR TITLE
Use matches!() macro where applicable

### DIFF
--- a/.github/workflows/rust_matrix.yml
+++ b/.github/workflows/rust_matrix.yml
@@ -12,7 +12,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.36.0  # MSRV
+          - 1.42.0  # MSRV
 
     steps:
       - uses: actions/checkout@v1

--- a/luomu-common/src/address.rs
+++ b/luomu-common/src/address.rs
@@ -17,18 +17,12 @@ pub enum Address {
 impl Address {
     /// True if IPv4 address
     pub fn is_ipv4(&self) -> bool {
-        match self {
-            Address::Ipv4(_) => true,
-            _ => false,
-        }
+        matches!(self, Address::Ipv4(_))
     }
 
     /// True if IPv6 address
     pub fn is_ipv6(&self) -> bool {
-        match self {
-            Address::Ipv6(_) => true,
-            _ => false,
-        }
+        matches!(self, Address::Ipv6(_))
     }
 
     /// True if either IPv4 or IPv6 address
@@ -38,10 +32,7 @@ impl Address {
 
     /// True if MAC address
     pub fn is_mac(&self) -> bool {
-        match self {
-            Address::Mac(_) => true,
-            _ => false,
-        }
+        matches!(self, Address::Mac(_))
     }
 
     /// Return the `Ipv4Addr` or None


### PR DESCRIPTION
Fixes clippy warning.
```
warning: match expression looks like `matches!` macro
  --> luomu-common/src/address.rs:20:9
   |
20 | /         match self {
21 | |             Address::Ipv4(_) => true,
22 | |             _ => false,
23 | |         }
   | |_________^ help: try this: `matches!(self, Address::Ipv4(_))`
   |
   = note: `#[warn(clippy::match_like_matches_macro)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro
```
