### PR TITLE
Small optimizations to error handling

### DIFF
--- a/luomu-libpcap/src/error.rs
+++ b/luomu-libpcap/src/error.rs
@@ -53,7 +53,10 @@ impl error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Break => write!(f, "libpcap: Loop terminated by pcap_breakloop (PCAP_ERROR_BREAK)."),
+            Error::Break => write!(
+                f,
+                "libpcap: Loop terminated by pcap_breakloop (PCAP_ERROR_BREAK)."
+            ),
             Error::NotActivated(interface) => {
                 write!(f, "libpcap: Capture handle for interface {} needs to be activated (PCAP_ERROR_NOT_ACTIVATED).", interface)
             }
@@ -61,19 +64,30 @@ impl fmt::Display for Error {
                 write!(f, "libpcap: Capture handle for interface {} is already activated (PCAP_ERROR_ACTIVATED).", interface)
             }
             Error::NoSuchDevice(interface) => {
-                write!(f, "libpcap: Capture interface {} doesn't exist (PCAP_ERROR_NO_SUCH_DEVICE).", interface)
+                write!(
+                    f,
+                    "libpcap: Capture interface {} doesn't exist (PCAP_ERROR_NO_SUCH_DEVICE).",
+                    interface
+                )
             }
             Error::MonitorModeNotSupported(interface) => {
                 write!(f, "libpcap: Capture interface {} doesn't support monitor mode (PCAP_ERROR_RFMON_NOTSUP).", interface)
             }
             Error::OnlySupportedInMonitorMode => {
-                write!(f, "libpcap: Operation is supported only in monitor mode (PCAP_ERROR_NOT_RFMON).")
+                write!(
+                    f,
+                    "libpcap: Operation is supported only in monitor mode (PCAP_ERROR_NOT_RFMON)."
+                )
             }
             Error::PermissionDenied(interface) => {
                 write!(f, "libpcap: Process doesn't have permission to open the capture interface {} (PCAP_ERROR_PERM_DENIED).", interface)
             }
             Error::InterfaceNotUp(interface) => {
-                write!(f, "libpcap: Capture interface {} is not up (PCAP_ERROR_IFACE_NOT_UP).", interface)
+                write!(
+                    f,
+                    "libpcap: Capture interface {} is not up (PCAP_ERROR_IFACE_NOT_UP).",
+                    interface
+                )
             }
             Error::TimestampTypeNotSupported(interface) => {
                 write!(f, "libpcap: Capture interface {} doesn't support setting the time stamp type (PCAP_ERROR_CANTSET_TSTAMP_TYPE).", interface)

--- a/luomu-libpcap/src/functions.rs
+++ b/luomu-libpcap/src/functions.rs
@@ -571,25 +571,20 @@ fn check_pcap_error(pcap_t: &PcapT, ret: i32) -> Result<()> {
         );
     }
 
-    let interface = pcap_t
-        .interface
-        .clone()
-        .unwrap_or_else(|| String::from("<unknown>"));
-
     match ret {
         PCAP_SUCCESS => Ok(()),
         PCAP_ERROR => Err(get_error(pcap_t)?),
         libpcap::PCAP_ERROR_BREAK => Err(Error::Break),
-        libpcap::PCAP_ERROR_NOT_ACTIVATED => Err(Error::NotActivated(interface)),
-        libpcap::PCAP_ERROR_ACTIVATED => Err(Error::AlreadyActivated(interface)),
-        libpcap::PCAP_ERROR_NO_SUCH_DEVICE => Err(Error::NoSuchDevice(interface)),
-        libpcap::PCAP_ERROR_RFMON_NOTSUP => Err(Error::MonitorModeNotSupported(interface)),
+        libpcap::PCAP_ERROR_NOT_ACTIVATED => Err(Error::NotActivated(pcap_t.get_inteface())),
+        libpcap::PCAP_ERROR_ACTIVATED => Err(Error::AlreadyActivated(pcap_t.get_inteface())),
+        libpcap::PCAP_ERROR_NO_SUCH_DEVICE => Err(Error::NoSuchDevice(pcap_t.get_inteface())),
+        libpcap::PCAP_ERROR_RFMON_NOTSUP => Err(Error::MonitorModeNotSupported(pcap_t.get_inteface())),
         libpcap::PCAP_ERROR_NOT_RFMON => Err(Error::OnlySupportedInMonitorMode),
-        libpcap::PCAP_ERROR_PERM_DENIED => Err(Error::PermissionDenied(interface)),
-        libpcap::PCAP_ERROR_IFACE_NOT_UP => Err(Error::InterfaceNotUp(interface)),
-        libpcap::PCAP_ERROR_CANTSET_TSTAMP_TYPE => Err(Error::TimestampTypeNotSupported(interface)),
+        libpcap::PCAP_ERROR_PERM_DENIED => Err(Error::PermissionDenied(pcap_t.get_inteface())),
+        libpcap::PCAP_ERROR_IFACE_NOT_UP => Err(Error::InterfaceNotUp(pcap_t.get_inteface())),
+        libpcap::PCAP_ERROR_CANTSET_TSTAMP_TYPE => Err(Error::TimestampTypeNotSupported(pcap_t.get_inteface())),
         libpcap::PCAP_ERROR_PROMISC_PERM_DENIED => {
-            Err(Error::PromiscuousPermissionDenied(interface))
+            Err(Error::PromiscuousPermissionDenied(pcap_t.get_inteface()))
         }
         libpcap::PCAP_ERROR_TSTAMP_PRECISION_NOTSUP => Err(Error::TimestampPrecisionNotSupported),
         n if n < 0 => Err(Error::PcapErrorCode(n)),

--- a/luomu-libpcap/src/functions.rs
+++ b/luomu-libpcap/src/functions.rs
@@ -300,7 +300,6 @@ pub fn pcap_next_ex(pcap_t: &PcapT) -> Result<Packet> {
     let mut packet: *const libc::c_uchar = std::ptr::null();
 
     let ret = unsafe { libpcap::pcap_next_ex(pcap_t.pcap_t, &mut header, &mut packet) };
-    check_pcap_error(pcap_t, ret)?;
 
     // pcap_next_ex() returns 1 if the packet was read without problems, 0 if
     // packets are being read from a live capture and the packet buffer timeout
@@ -308,7 +307,7 @@ pub fn pcap_next_ex(pcap_t: &PcapT) -> Result<Packet> {
     match ret {
         1 => (),
         0 => return Err(Error::Timeout),
-        n => return Err(Error::PcapErrorCode(n)),
+        n => check_pcap_error(pcap_t, n)?,
     }
 
     if header.is_null() || packet.is_null() {

--- a/luomu-libpcap/src/functions.rs
+++ b/luomu-libpcap/src/functions.rs
@@ -578,11 +578,15 @@ fn check_pcap_error(pcap_t: &PcapT, ret: i32) -> Result<()> {
         libpcap::PCAP_ERROR_NOT_ACTIVATED => Err(Error::NotActivated(pcap_t.get_inteface())),
         libpcap::PCAP_ERROR_ACTIVATED => Err(Error::AlreadyActivated(pcap_t.get_inteface())),
         libpcap::PCAP_ERROR_NO_SUCH_DEVICE => Err(Error::NoSuchDevice(pcap_t.get_inteface())),
-        libpcap::PCAP_ERROR_RFMON_NOTSUP => Err(Error::MonitorModeNotSupported(pcap_t.get_inteface())),
+        libpcap::PCAP_ERROR_RFMON_NOTSUP => {
+            Err(Error::MonitorModeNotSupported(pcap_t.get_inteface()))
+        }
         libpcap::PCAP_ERROR_NOT_RFMON => Err(Error::OnlySupportedInMonitorMode),
         libpcap::PCAP_ERROR_PERM_DENIED => Err(Error::PermissionDenied(pcap_t.get_inteface())),
         libpcap::PCAP_ERROR_IFACE_NOT_UP => Err(Error::InterfaceNotUp(pcap_t.get_inteface())),
-        libpcap::PCAP_ERROR_CANTSET_TSTAMP_TYPE => Err(Error::TimestampTypeNotSupported(pcap_t.get_inteface())),
+        libpcap::PCAP_ERROR_CANTSET_TSTAMP_TYPE => {
+            Err(Error::TimestampTypeNotSupported(pcap_t.get_inteface()))
+        }
         libpcap::PCAP_ERROR_PROMISC_PERM_DENIED => {
             Err(Error::PromiscuousPermissionDenied(pcap_t.get_inteface()))
         }

--- a/luomu-libpcap/src/lib.rs
+++ b/luomu-libpcap/src/lib.rs
@@ -57,6 +57,17 @@ pub struct PcapT {
 }
 
 impl PcapT {
+    /// get interface name
+    ///
+    /// `get_interface` returns the interface name if known or "<unknown>".
+    pub fn get_inteface(&self) -> String {
+        if let Some(name) = &self.interface {
+            name.to_owned()
+        } else {
+            String::from("<unknown>")
+        }
+    }
+
     /// get libpcap error message text
     ///
     /// `get_error()` returns the error pertaining to the last pcap library error.


### PR DESCRIPTION
1. Move generic error check later after happy path is handled
   The `pcap_next_ex()` function is called for every packet. And usually packet is received without error or timeout happens. Handle these cases first and check for errors later.

    This change avoids calling `check_pcap_error()` for every received packet.

1. Make check_pcap_error() return fast for PCAP_SUCCESS/PCAP_ERROR
    These two values don't care about the interface name, and success or error is checked for all the time. Thus handle early and return fast before doing the interface String copying business.