### PR TITLE
Add AsyncCapture for testing how asynchronous pcap could work

### DIFF
--- a/luomu-libpcap/Cargo.toml
+++ b/luomu-libpcap/Cargo.toml
@@ -13,12 +13,23 @@ readme = "README.md"
 keywords = [ "pcap", "libpcap", "network" ]
 categories = [ "api-bindings", "network-programming" ]
 
+[features]
+default = []
+async-tokio = [ "futures-core", "tokio" ]
+
 [dependencies]
 libc = { version = "0.2", default-features = false }
 log = { version = "0.4", default-features = false }
 luomu-common = { path = "../luomu-common" }
 luomu-libpcap-sys = { path = "../luomu-libpcap-sys" }
 
+# async-tokio
+futures-core = { version = "0.3", optional = true }
+tokio = { version = "1", optional = true, features = [ "rt-multi-thread", "sync" ] }
+
 [dev-dependencies]
 anyhow = "1"
-env_logger = {version = "0.8", default-features = false }
+env_logger = { version = "0.8", default-features = false }
+futures-util = { version = "0.3", default-features = false }
+luomu-libpcap = { path = ".", features = [ "async-tokio" ] }
+tokio = { version = "1", features = [ "rt-multi-thread", "time" ] }

--- a/luomu-libpcap/examples/tokio-capture.rs
+++ b/luomu-libpcap/examples/tokio-capture.rs
@@ -1,0 +1,40 @@
+use anyhow::Result;
+use std::time::Duration;
+
+use futures_util::TryStreamExt;
+
+use luomu_libpcap::tokio as tokio_capture;
+use luomu_libpcap::Pcap;
+
+fn main() -> Result<()> {
+    env_logger::init();
+    let runtime = tokio::runtime::Runtime::new()?;
+    runtime.block_on(async { capture("en0").await })
+}
+
+async fn capture(interface: &'static str) -> Result<()> {
+    let pcap = Pcap::builder(interface)?
+        .set_promiscuous(true)?
+        .set_snaplen(65535)?
+        .set_timeout(Duration::from_millis(1000))?
+        .activate()?;
+
+    tokio::task::spawn(async { ticker().await });
+
+    let mut pcap = tokio_capture::AsyncCapture::new(pcap)?;
+
+    while let Some(packet) = pcap.try_next().await? {
+        println!("{:?}", packet.timestamp());
+    }
+
+    Ok(())
+}
+
+async fn ticker() {
+    let mut counter = 0;
+    loop {
+        println!("tick {}", counter);
+        counter += 1;
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}

--- a/luomu-libpcap/src/error.rs
+++ b/luomu-libpcap/src/error.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::io;
 
 /// Errors produced by luomu-libpcap.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     /// Loop terminated by pcap_breakloop (PCAP_ERROR_BREAK).
     Break,
@@ -48,7 +48,7 @@ pub enum Error {
     CStringError(CStringError),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum CStringError {
     Utf8(std::str::Utf8Error),
     Nul(std::ffi::NulError),

--- a/luomu-libpcap/src/lib.rs
+++ b/luomu-libpcap/src/lib.rs
@@ -55,6 +55,11 @@ pub struct PcapT {
     interface: Option<String>,
 }
 
+// I assume the pcap_t pointer is safe to move between threads, but it can only
+// be used from one thread. libpcap documentation is vague about thread safety,
+// so we try this.
+unsafe impl Send for PcapT {}
+
 impl PcapT {
     /// get interface name
     ///

--- a/luomu-libpcap/src/tokio.rs
+++ b/luomu-libpcap/src/tokio.rs
@@ -1,0 +1,75 @@
+//! Tokio support for libpcap
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_core::stream::Stream;
+use tokio::sync::mpsc::{self, UnboundedSender};
+use tokio::task;
+
+use crate::functions as libpcap;
+use crate::Error;
+use crate::OwnedPacket;
+
+/// Asynchronous Capture
+///
+/// This type uses Tokio's blocking task to run a libpcap capture loop.
+#[derive(Debug)]
+pub struct AsyncCapture {
+    rx: mpsc::UnboundedReceiver<crate::Result<OwnedPacket>>,
+}
+
+impl AsyncCapture {
+    /// Construct new packet capture instance.
+    pub fn new(pcap: crate::Pcap) -> crate::Result<Self> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        task::spawn_blocking(|| capture_loop(pcap, tx));
+        Ok(Self { rx })
+    }
+}
+
+impl Future for AsyncCapture {
+    type Output = crate::Result<OwnedPacket>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.rx.poll_recv(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Some(value)) => Poll::Ready(value),
+            Poll::Ready(None) => Poll::Ready(Err(Error::Break)),
+        }
+    }
+}
+
+impl Stream for AsyncCapture {
+    type Item = crate::Result<OwnedPacket>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.poll(cx).map(Option::Some)
+    }
+}
+
+fn capture_loop(pcap: crate::Pcap, tx: UnboundedSender<crate::Result<OwnedPacket>>) {
+    loop {
+        match next_packet(&pcap) {
+            Poll::Pending => continue,
+            Poll::Ready(ret) => {
+                let is_err = ret.is_err();
+                if tx.send(ret).is_err() {
+                    return;
+                }
+                if is_err {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+fn next_packet(pcap: &crate::Pcap) -> Poll<crate::Result<OwnedPacket>> {
+    match libpcap::pcap_next_ex(&pcap.pcap_t) {
+        Ok(p) => Poll::Ready(Ok(p.into())),
+        Err(e) if e == Error::Timeout => Poll::Pending,
+        Err(e) => Poll::Ready(Err(e)),
+    }
+}


### PR DESCRIPTION
The AsyncCapture implements Future and Stream, and is async framework agnostic.

However, due to how libpcap works and this implementation we rely on libpcap's pcap_next_ex() timeouts and/or packet buffers to return once in a while to let other tasks run.