### PR TITLE
Remove Box<dyn Error> from our error type

### DIFF
--- a/luomu-libpcap/Cargo.toml
+++ b/luomu-libpcap/Cargo.toml
@@ -20,4 +20,5 @@ luomu-common = { path = "../luomu-common" }
 luomu-libpcap-sys = { path = "../luomu-libpcap-sys" }
 
 [dev-dependencies]
+anyhow = "1"
 env_logger = {version = "0.8", default-features = false }

--- a/luomu-libpcap/tests/errors.rs
+++ b/luomu-libpcap/tests/errors.rs
@@ -1,0 +1,8 @@
+#[test]
+fn test_anyhow_error() {
+    fn do_stuff() -> anyhow::Result<()> {
+        let _ = luomu_libpcap::Pcap::new("lo0")?;
+        Ok(())
+    }
+    let _ = do_stuff();
+}


### PR DESCRIPTION
This type wasn't compatible with anyhow crate. This is just band aid to get forward. Proper fix might be to switch to thiserror crate for our Error type.