### PR TITLE
Add support for reading packets from saved pcap file

### DIFF
--- a/.github/workflows/rust_matrix.yml
+++ b/.github/workflows/rust_matrix.yml
@@ -12,7 +12,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.43.1  # MSRV
+          - 1.46.0  # MSRV
 
     steps:
       - uses: actions/checkout@v1

--- a/luomu-libpcap/examples/offline.rs
+++ b/luomu-libpcap/examples/offline.rs
@@ -1,0 +1,29 @@
+use std::env;
+
+use luomu_libpcap::Pcap;
+fn main() {
+    env_logger::init();
+    let fname = match env::args().nth(1) {
+        None => {
+            log::error!("No PCAP file name given");
+            return;
+        }
+        Some(n) => n,
+    };
+
+    let pcap = Pcap::offline(&fname).unwrap();
+    for (count, pkt) in pcap.capture().enumerate() {
+        let packet = pkt.packet();
+        let mut hex = String::new();
+        for i in 0..packet.len() {
+            if i % 4 == 0 {
+                hex.push(' ');
+            }
+            if i % 32 == 0 {
+                hex.push('\n');
+            }
+            hex.push_str(&format!("{:02x}", packet[i]));
+        }
+        println!("Packet {} ({} bytes): {}", count + 1, packet.len(), hex);
+    }
+}

--- a/luomu-libpcap/src/lib.rs
+++ b/luomu-libpcap/src/lib.rs
@@ -32,6 +32,7 @@ use std::convert::TryFrom;
 use std::default;
 use std::net::IpAddr;
 use std::ops::Deref;
+use std::path::Path;
 use std::result;
 use std::time::{Duration, SystemTime};
 
@@ -116,6 +117,16 @@ impl Pcap {
     pub fn new(source: &str) -> Result<Pcap> {
         let pcap_t = pcap_create(source)?;
         Ok(Pcap { pcap_t })
+    }
+
+    /// Create a capture handle for reading packets from given savefile.
+    ///
+    /// This function can be used to create handle to read packes from saved
+    /// pcap -file. Use `capture()` to get iterator for packets in the file.
+    pub fn offline<P: AsRef<Path>>(savefile: P) -> Result<Pcap> {
+        Ok(Pcap {
+            pcap_t: pcap_open_offline(savefile)?,
+        })
     }
 
     /// Use builder to create a live capture handle

--- a/luomu-tpacketv3/src/lib.rs
+++ b/luomu-tpacketv3/src/lib.rs
@@ -128,7 +128,7 @@ pub fn reader<'a>(
     pcap_filter: Option<&str>,
     parameters: ReaderParameters,
 ) -> Result<Reader<'a>, String> {
-    let index = ifindex_for(&interface);
+    let index = ifindex_for(interface);
     trace!("Index for interface {} is {}", interface, index);
     let sock = socket::Fd::create().map_err(|e| format!("Can not create socket {}", e))?;
 


### PR DESCRIPTION
Adds `Pcap::offline()` method to start reading packets from file instead of reading live traffic from interface.