### PR TITLE
Add optional support for bytes crate

### DIFF
--- a/luomu-libpcap/Cargo.toml
+++ b/luomu-libpcap/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 async-tokio = [ "futures-core", "tokio" ]
 
 [dependencies]
+bytes = { version = "1", optional = true }
 libc = { version = "0.2", default-features = false }
 log = { version = "0.4", default-features = false }
 luomu-common = { path = "../luomu-common" }

--- a/luomu-libpcap/src/lib.rs
+++ b/luomu-libpcap/src/lib.rs
@@ -406,6 +406,12 @@ impl Packet {
         unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
     }
 
+    /// Get the contents of a packet as `Bytes`. This makes a copy of the data.
+    #[cfg(feature = "bytes")]
+    pub fn packet_bytes(&self) -> bytes::Bytes {
+        bytes::Bytes::copy_from_slice(self.packet())
+    }
+
     /// Length of captured packet.
     ///
     /// Packet should always have some bytes so length is never zero.
@@ -441,6 +447,12 @@ impl OwnedPacket {
     /// Get the contents of a packet.
     pub fn packet(&self) -> &[u8] {
         &self.packet
+    }
+
+    /// Get the contents of a packet  as `Bytes` without copying.
+    #[cfg(feature = "bytes")]
+    pub fn packet_bytes(self) -> bytes::Bytes {
+        bytes::Bytes::from(self.packet)
     }
 
     /// Length of captured packet.


### PR DESCRIPTION
This allows accessing packet contents as [Bytes](https://docs.rs/bytes/latest/bytes/struct.Bytes.html). It implies copying the packet contents once, but after that Bytes should allow slicing'n'dicing itself without further need for copying.