### PR TITLE
Change MacAddr to hold u64 instead of byte array

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,9 @@ unused = { level = "deny", priority = -1 }
 missing_docs = { level = "deny", priority = -1 }
 unsafe-code = "deny"
 
+# Allow cfg(kani)
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
+
 # Remove these after moving to Rust 2024 edition
 tail_expr_drop_order = "allow"
 if_let_rescope = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/sensorfu/luomu-libpcap"
 [workspace]
 resolver = "2"
 members = [
+	# "fuzz",
 	"luomu-common",
 	"luomu-libpcap",
 	"luomu-libpcap-sys",

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "luomu-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+luomu-common.path = "../luomu-common/"
+
+[[bin]]
+name = "macaddr-from-str"
+path = "fuzz_targets/macaddr-from-str.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/macaddr-from-str.rs
+++ b/fuzz/fuzz_targets/macaddr-from-str.rs
@@ -1,0 +1,9 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use std::str::FromStr;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        _ = luomu_common::MacAddr::from_str(s);
+    }
+});

--- a/luomu-common/src/lib.rs
+++ b/luomu-common/src/lib.rs
@@ -21,7 +21,7 @@ pub use addr_pair::{AddrPair, IPPair, MacPair, PortPair};
 pub mod ipaddr;
 
 /// Invalid address error
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InvalidAddress;
 
 impl std::error::Error for InvalidAddress {}
@@ -31,3 +31,23 @@ impl fmt::Display for InvalidAddress {
         f.write_str("invalid address")
     }
 }
+
+/// Errors specific to VLAN IDs (tags)
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TagError {
+    /// Tag stack is full and no additional tags can be added
+    TooManyTags,
+    /// The given tag is too large
+    TooLargeTag,
+}
+
+impl fmt::Display for TagError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TagError::TooLargeTag => f.write_str("the given tag is too large"),
+            TagError::TooManyTags => f.write_str("too many VLAN tags"),
+        }
+    }
+}
+
+impl std::error::Error for TagError {}

--- a/luomu-common/src/lib.rs
+++ b/luomu-common/src/lib.rs
@@ -16,6 +16,9 @@ pub use directed_addr::{Destination, Source};
 mod addr_pair;
 pub use addr_pair::{AddrPair, IPPair, MacPair, PortPair};
 
+mod tagged_macaddr;
+pub use tagged_macaddr::TaggedMacAddr;
+
 /// Functions to check if IP addresses are valid for source, destination or
 /// forwardable
 pub mod ipaddr;

--- a/luomu-common/src/macaddr.rs
+++ b/luomu-common/src/macaddr.rs
@@ -178,11 +178,11 @@ impl FromStr for MacAddr {
             .filter(|s| s.chars().all(|c| c.is_ascii_hexdigit()))
             .map(|v| u8::from_str_radix(v, 16).ok())
             .enumerate()
-            .try_fold(([0u8; 6], 0), |(mut addr, _), (i, v)| {
+            .try_fold((0, [0u8; 6]), |(_, mut addr), (i, v)| {
                 addr[i] = v?;
-                Some((addr, i))
+                Some((i, addr))
             })
-            .map_or(Err(InvalidAddress), |(val, i)| match i {
+            .map_or(Err(InvalidAddress), |(i, val)| match i {
                 5 => Ok(MacAddr::from(val)),
                 _ => Err(InvalidAddress),
             })

--- a/luomu-common/src/macaddr.rs
+++ b/luomu-common/src/macaddr.rs
@@ -42,7 +42,7 @@ impl MacAddr {
     /// A broadcast MAC address (FF:FF:FF:FF:FF:FF)
     pub const BROADCAST: MacAddr = MacAddr(MAC_BITS);
 
-    /// Return MAC address as bytearray in big endian order.
+    /// Return MAC address as byte array in big endian order.
     pub fn as_array(&self) -> [u8; 6] {
         // Taking range of [2,7] is safe from u64. See kani proof in bunnies
         // module.
@@ -404,5 +404,25 @@ mod tests {
 
             vlan == mac.pop_tag().unwrap()
         }
+    }
+}
+
+#[cfg(kani)]
+mod bunnies {
+    use crate::MacAddr;
+
+    #[kani::proof]
+    fn check_macaddr_try_from() {
+        let i: u64 = kani::any();
+        kani::assume(i <= 0x00FFFFFFFFFFFF);
+        assert!(MacAddr::try_from(i).is_ok());
+    }
+
+    #[kani::proof]
+    fn check_macaddr_as_array() {
+        let i: u64 = kani::any();
+        kani::assume(i <= 0x00FFFFFFFFFFFF);
+        let mac = MacAddr::try_from(i).unwrap();
+        mac.as_array();
     }
 }

--- a/luomu-common/src/tagged_macaddr.rs
+++ b/luomu-common/src/tagged_macaddr.rs
@@ -1,0 +1,213 @@
+use crate::{MacAddr, TagError};
+
+// Size of our tag stack. 64bit integer can store up to five VLAN tags.
+type TagStack = u64;
+
+/// A [MacAddr] with additional support for storing stack of VLAN IDs.
+///
+/// Tags are stored as a stack where the outermost tag should be pushed first
+/// and popped last (aka LIFO). There's enough room to store up to five VLAN
+/// IDs.
+///
+/// ```rust
+/// use luomu_common::{MacAddr, TaggedMacAddr};
+///
+/// let mut mac = TaggedMacAddr::new("11:22:33:aa:bb:cc".parse().unwrap());
+/// assert_eq!(mac.pop_tag(), None);
+///
+/// mac.push_tag(42);
+/// mac.push_tag(1337);
+/// assert_eq!(mac.pop_tag(), Some(1337));
+/// assert_eq!(mac.pop_tag(), Some(42));
+/// assert_eq!(mac.pop_tag(), None);
+/// ```
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TaggedMacAddr {
+    mac: MacAddr,
+    tag_stack: TagStack,
+}
+
+impl TaggedMacAddr {
+    /// Construct new [TaggedMacAddr].
+    pub const fn new(mac: MacAddr) -> Self {
+        Self { mac, tag_stack: 0 }
+    }
+
+    /// Get a reference to a [MacAddr].
+    pub fn mac(&self) -> &MacAddr {
+        &self.mac
+    }
+
+    /// Get a mutable reference to [MacAddr].
+    pub fn mac_mut(&mut self) -> &mut MacAddr {
+        &mut self.mac
+    }
+
+    /// Push a VLAN tag into the stack. The outermost tag should be pushed
+    /// first.
+    pub const fn push_tag(&mut self, tag: u16) -> Result<(), TagError> {
+        if tag > 0x0FFF {
+            return Err(TagError::TooLargeTag);
+        }
+
+        #[allow(clippy::unusual_byte_groupings)] // groups of 12 bits
+        if self.tag_stack & 0x0FFF_000_000_000_000 == 0 {
+            self.tag_stack = self.tag_stack << 12 | tag as TagStack;
+            return Ok(());
+        }
+
+        Err(TagError::TooManyTags)
+    }
+
+    /// Pop a VLAN tag from the stack. The innermost tag pops out first.
+    pub const fn pop_tag(&mut self) -> Option<u16> {
+        let Some(tag) = self.peek_tag() else {
+            return None;
+        };
+        self.tag_stack >>= 12;
+        Some(tag)
+    }
+
+    /// Peek a next tag in stack, but don't pop it out.
+    pub const fn peek_tag(&self) -> Option<u16> {
+        let tag = self.tag_stack & 0x0000000000000FFF;
+        if tag > 0 {
+            return Some(tag as u16);
+        }
+
+        None
+    }
+
+    /// Get all tags as an array.
+    #[allow(clippy::unusual_byte_groupings)]
+    pub fn tag_array(&self) -> [u16; 5] {
+        let mut tags = [0u16; 5];
+        tags[0] = ((self.tag_stack & 0x0FFF_000_000_000_000) >> 48) as u16;
+        tags[1] = ((self.tag_stack & 0x0000_FFF_000_000_000) >> 36) as u16;
+        tags[2] = ((self.tag_stack & 0x0000_000_FFF_000_000) >> 24) as u16;
+        tags[3] = ((self.tag_stack & 0x0000_000_000_FFF_000) >> 12) as u16;
+        tags[4] = (self.tag_stack & 0x0000_000_000_000_FFF) as u16;
+        tags
+    }
+}
+
+impl From<MacAddr> for TaggedMacAddr {
+    fn from(mac: MacAddr) -> Self {
+        Self::new(mac)
+    }
+}
+
+impl From<TaggedMacAddr> for MacAddr {
+    fn from(tagged_mac: TaggedMacAddr) -> Self {
+        tagged_mac.mac
+    }
+}
+
+impl std::ops::Deref for TaggedMacAddr {
+    type Target = MacAddr;
+
+    fn deref(&self) -> &Self::Target {
+        self.mac()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{MacAddr, TagError, TaggedMacAddr};
+
+    #[test]
+    fn test_tagged_macaddr_large_tag() {
+        let mac: MacAddr = "11:22:33:AA:BB:CC".parse().unwrap();
+        let mut tagged_mac: TaggedMacAddr = mac.into();
+        assert_eq!(tagged_mac.push_tag(0x1000), Err(TagError::TooLargeTag));
+    }
+
+    #[test]
+    fn test_tagged_macaddr_tag_push_pop() {
+        let mac: MacAddr = "11:22:33:AA:BB:CC".parse().unwrap();
+        let mut tagged_mac: TaggedMacAddr = mac.into();
+        assert_eq!(tagged_mac.pop_tag(), None);
+
+        tagged_mac.push_tag(42).unwrap();
+        assert_eq!(tagged_mac.pop_tag(), Some(42));
+
+        tagged_mac.push_tag(42).unwrap();
+        tagged_mac.push_tag(1337).unwrap();
+        tagged_mac.push_tag(0x0FFF).unwrap();
+        tagged_mac.push_tag(3).unwrap();
+        tagged_mac.push_tag(2).unwrap();
+        assert_eq!(tagged_mac.push_tag(1), Err(TagError::TooManyTags));
+
+        assert_eq!(tagged_mac.pop_tag(), Some(2));
+        assert_eq!(tagged_mac.pop_tag(), Some(3));
+        assert_eq!(tagged_mac.pop_tag(), Some(0x0FFF));
+        assert_eq!(tagged_mac.pop_tag(), Some(1337));
+        assert_eq!(tagged_mac.pop_tag(), Some(42));
+        assert_eq!(tagged_mac.pop_tag(), None);
+    }
+
+    #[test]
+    fn test_tagged_macaddr_peek() {
+        let mac: MacAddr = "11:22:33:AA:BB:CC".parse().unwrap();
+        let mut tagged_mac: TaggedMacAddr = mac.into();
+        assert_eq!(tagged_mac.pop_tag(), None);
+        assert_eq!(tagged_mac.peek_tag(), None);
+
+        tagged_mac.push_tag(42).unwrap();
+        tagged_mac.push_tag(1337).unwrap();
+        assert_eq!(tagged_mac.peek_tag(), Some(1337));
+        assert_eq!(tagged_mac.pop_tag(), Some(1337));
+        assert_eq!(tagged_mac.peek_tag(), Some(42));
+        assert_eq!(tagged_mac.pop_tag(), Some(42));
+        assert_eq!(tagged_mac.peek_tag(), None);
+        assert_eq!(tagged_mac.pop_tag(), None);
+    }
+
+    #[test]
+    fn test_mac() {
+        let mac: MacAddr = "11:22:33:AA:BB:CC".parse().unwrap();
+        let tagged_mac: TaggedMacAddr = mac.into();
+
+        assert_eq!(tagged_mac.mac().is_unspecified(), false);
+    }
+
+    #[test]
+    fn test_mac_mut() {
+        let mac: MacAddr = "11:22:33:AA:BB:CC".parse().unwrap();
+        let mut tagged_mac: TaggedMacAddr = mac.into();
+
+        assert_eq!(tagged_mac.mac().peek_tag(), None);
+        assert_eq!(tagged_mac.mac_mut().push_tag(42), Ok(()));
+        assert_eq!(tagged_mac.mac_mut().pop_tag(), Some(42));
+        assert_eq!(tagged_mac.mac().peek_tag(), None);
+    }
+
+    #[test]
+    fn test_tagged_macaddr_tag_array() {
+        let mac: MacAddr = "11:22:33:AA:BB:CC".parse().unwrap();
+        let mut tagged_mac: TaggedMacAddr = mac.into();
+        assert_eq!(tagged_mac.tag_array(), [0; 5]);
+
+        tagged_mac.push_tag(42).unwrap();
+        tagged_mac.push_tag(1337).unwrap();
+        tagged_mac.push_tag(0x0FFF).unwrap();
+        tagged_mac.push_tag(3).unwrap();
+        tagged_mac.push_tag(2).unwrap();
+        assert_eq!(tagged_mac.tag_array(), [42, 1337, 0x0FFF, 3, 2]);
+    }
+
+    #[test]
+    fn test_deref_peek_tag() {
+        let mut mac: MacAddr = "11:22:33:AA:BB:CC".parse().unwrap();
+        mac.push_tag(42).unwrap();
+
+        let mut tagged_mac: TaggedMacAddr = mac.into();
+        tagged_mac.push_tag(1337).unwrap();
+
+        // This peek_tag is for TaggedMacAddr
+        assert_eq!(tagged_mac.peek_tag(), Some(1337));
+
+        // This peek_tag is for MacAddr via dereference
+        assert_eq!((*tagged_mac).peek_tag(), Some(42));
+    }
+}


### PR DESCRIPTION
Compiler probably does this anyway. And this way we can have access to upper two bytes if we want to.