### PR TITLE
Add trait for address pairs and introduce types required

### DIFF
--- a/luomu-common/src/addr_pair.rs
+++ b/luomu-common/src/addr_pair.rs
@@ -1,0 +1,227 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use crate::MacAddr;
+
+use super::{Destination, Source};
+
+/// In network protocol implementations addresses usually comes in pairs: Source
+/// and destination IP address, source and destination ports, etc.
+///
+/// This trait is abstraction of this idea.
+pub trait AddrPair<ADDR> {
+    /// Construct new [AddrPair] with given [Source] and [Destination]
+    /// addresses.
+    fn new(src: Source<ADDR>, dst: Destination<ADDR>) -> Self;
+
+    /// Return source address from address pair.
+    fn source(&self) -> Source<ADDR>;
+
+    /// Return destination address from address pair.
+    fn destination(&self) -> Destination<ADDR>;
+
+    /// Return new address pair with source and destination addresses flipped.
+    fn flip(&self) -> Self;
+}
+
+/// In protocols IP addresses usually appear in pairs: Source and destination
+/// IP. This enum provides such pair for both IPv4 and IPv6 addresses.
+///
+/// Main benefit of using this is to have the protocol version associated with
+/// both addresses at the same time providing ergonomics and a bit less memory
+/// consumption.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum IPPair {
+    /// IPv4 address pair
+    V4 {
+        /// Source IPv4 address
+        src: Source<Ipv4Addr>,
+        /// Destination IPv4 address
+        dst: Destination<Ipv4Addr>,
+    },
+    /// IPv6 address pair
+    V6 {
+        /// Source IPv6 address
+        src: Source<Ipv6Addr>,
+        /// Destination IPv4 address
+        dst: Destination<Ipv6Addr>,
+    },
+}
+
+impl AddrPair<IpAddr> for IPPair {
+    /// Construct a new `IPPair`.
+    ///
+    /// # Panics
+    /// Both [IpAddr] need to be same IP version or the call will panic. Use
+    /// [IPPair::new_v4] or [IPPair::new_v6] instead for safe versions.
+    fn new(src: Source<IpAddr>, dst: Destination<IpAddr>) -> IPPair {
+        match (src.unwrap(), dst.unwrap()) {
+            (IpAddr::V4(src), IpAddr::V4(dst)) => {
+                IPPair::new_v4(Source::new(src), Destination::new(dst))
+            }
+            (IpAddr::V6(src), IpAddr::V6(dst)) => {
+                IPPair::new_v6(Source::new(src), Destination::new(dst))
+            }
+            _ => panic!(
+                "IPPair::new() invalid IP address families provided. src: {:?}, dst: {:?}",
+                src, dst
+            ),
+        }
+    }
+
+    /// Returns the source IP address from pair.
+    fn source(&self) -> Source<IpAddr> {
+        match self {
+            IPPair::V4 { src, .. } => Source::new(IpAddr::from(src.unwrap())),
+            IPPair::V6 { src, .. } => Source::new(IpAddr::from(src.unwrap())),
+        }
+    }
+
+    /// Returns the destination IP address from pair.
+    fn destination(&self) -> Destination<IpAddr> {
+        match self {
+            IPPair::V4 { dst, .. } => Destination::new(IpAddr::from(dst.unwrap())),
+            IPPair::V6 { dst, .. } => Destination::new(IpAddr::from(dst.unwrap())),
+        }
+    }
+
+    /// Flip source and destination around: Source is new destination and
+    /// destination is new source.
+    fn flip(&self) -> IPPair {
+        IPPair::new(self.destination().flip(), self.source().flip())
+    }
+}
+
+impl IPPair {
+    /// Construct a new `IPPair` from two [Ipv4Addr].
+    pub const fn new_v4(src: Source<Ipv4Addr>, dst: Destination<Ipv4Addr>) -> IPPair {
+        IPPair::V4 { src, dst }
+    }
+
+    /// Construct a new `IPPair` from two [Ipv6Addr].
+    pub const fn new_v6(src: Source<Ipv6Addr>, dst: Destination<Ipv6Addr>) -> IPPair {
+        IPPair::V6 { src, dst }
+    }
+
+    /// Returns true if IP pair are IPv4 addresses.
+    pub const fn is_ipv4(&self) -> bool {
+        matches!(self, IPPair::V4 { .. })
+    }
+
+    /// Returns true if IP pair are IPv6 addresses.
+    pub const fn is_ipv6(&self) -> bool {
+        matches!(self, IPPair::V6 { .. })
+    }
+}
+
+/// TCP and UDP use 16 bit port numbers and protocol implementations need to
+/// handle both source and destination port numbers together. This keeps both
+/// port numbers.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub struct PortPair {
+    src: Source<u16>,
+    dst: Destination<u16>,
+}
+
+impl AddrPair<u16> for PortPair {
+    /// Construct new `PortPair` with `Source` and `Destination` ports.
+    fn new(src: Source<u16>, dst: Destination<u16>) -> PortPair {
+        Self { src, dst }
+    }
+
+    /// Return the source port.
+    fn source(&self) -> Source<u16> {
+        self.src
+    }
+
+    /// Return the destionation port.
+    fn destination(&self) -> Destination<u16> {
+        self.dst
+    }
+
+    /// Flip source and destination ports.
+    fn flip(&self) -> PortPair {
+        Self {
+            src: self.dst.flip(),
+            dst: self.src.flip(),
+        }
+    }
+}
+
+/// A pair of MAC addresses.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub struct MacPair {
+    src: Source<MacAddr>,
+    dst: Destination<MacAddr>,
+}
+
+impl AddrPair<MacAddr> for MacPair {
+    /// Construct new `MacPair` with `Source` and `Destination` MAC addresses.
+    fn new(src: Source<MacAddr>, dst: Destination<MacAddr>) -> Self {
+        Self { src, dst }
+    }
+
+    /// Return the source Mac.
+    fn source(&self) -> Source<MacAddr> {
+        self.src
+    }
+
+    /// Return the destionation Mac.
+    fn destination(&self) -> Destination<MacAddr> {
+        self.dst
+    }
+
+    /// Flip source and destination MAC addresses.
+    fn flip(&self) -> Self {
+        Self {
+            src: self.dst.flip(),
+            dst: self.src.flip(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    use crate::{AddrPair, Destination, IPPair, PortPair, Source};
+
+    #[test]
+    fn test_ip4_pair() {
+        let ip1: Ipv4Addr = "192.0.2.5".parse().unwrap();
+        let ip2: Ipv4Addr = "198.51.100.255".parse().unwrap();
+
+        let ippair1 = IPPair::new_v4(Source::new(ip1), Destination::new(ip2));
+        let ippair2 = ippair1.flip();
+        assert_eq!(ippair2.source().unwrap(), ip2);
+        assert_eq!(ippair2.destination().unwrap(), ip1);
+    }
+
+    #[test]
+    fn test_ip6_pair() {
+        let ip1: Ipv6Addr = "2001:db8::1".parse().unwrap();
+        let ip2: Ipv6Addr = "2001:db8:42::12:765".parse().unwrap();
+
+        let ippair1 = IPPair::new_v6(Source::new(ip1), Destination::new(ip2));
+        let ippair2 = ippair1.flip();
+        assert_eq!(ippair2.source().unwrap(), ip2);
+        assert_eq!(ippair2.destination().unwrap(), ip1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_ip_pair_fail() {
+        let ip1: IpAddr = "192.0.2.5".parse().unwrap();
+        let ip2: IpAddr = "2001:db8:42::12:765".parse().unwrap();
+
+        IPPair::new(Source::new(ip1), Destination::new(ip2));
+    }
+
+    #[test]
+    fn test_port_pair() {
+        let (p1, p2) = (42, 12765);
+        let port_pair = PortPair::new(Source::new(p1), Destination::new(p2));
+        let flipped = port_pair.flip();
+        assert_eq!(p1, flipped.destination().unwrap());
+        assert_eq!(p2, flipped.source().unwrap());
+    }
+}

--- a/luomu-common/src/directed_addr.rs
+++ b/luomu-common/src/directed_addr.rs
@@ -1,0 +1,106 @@
+/// A `Source` of any kind. For example an IP address.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub struct Source<ADDR>(ADDR);
+
+impl<ADDR> Source<ADDR> {
+    /// Constructs a new `Source`.
+    pub const fn new(addr: ADDR) -> Self {
+        Self(addr)
+    }
+
+    /// Make a [Destination] out from `Source`.
+    pub fn flip(self) -> Destination<ADDR> {
+        Destination(self.unwrap())
+    }
+
+    /// Returns the underlying value inside `Source`.
+    pub fn unwrap(self) -> ADDR {
+        self.0
+    }
+}
+
+/// A `Destination` of any kind. For example an IP address.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub struct Destination<ADDR>(ADDR);
+
+impl<ADDR> Destination<ADDR> {
+    /// Constructs a new `Destination`.
+    pub const fn new(addr: ADDR) -> Self {
+        Self(addr)
+    }
+
+    /// Make a [Source] out from `Destination`.
+    pub fn flip(self) -> Source<ADDR> {
+        Source(self.unwrap())
+    }
+
+    /// Returns the underlying value inside `Destination`.
+    pub fn unwrap(self) -> ADDR {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+
+    use super::{Destination, Source};
+
+    #[test]
+    fn test_src_dst_flip() {
+        let i1 = Destination::new(42);
+        let i2 = i1.flip();
+        let i3 = i2.flip();
+
+        assert_eq!(i2.unwrap(), 42);
+        assert_eq!(i1, i3);
+    }
+
+    #[test]
+    fn test_src_dst_ipaddr() {
+        let ip1 = Destination::new(Ipv4Addr::UNSPECIFIED);
+        let ip2 = Source::new(Ipv4Addr::UNSPECIFIED);
+        let ip3 = Destination::new(Ipv6Addr::UNSPECIFIED);
+        let ip4 = Source::new(Ipv6Addr::UNSPECIFIED);
+
+        let ip5 = Destination::new(IpAddr::from(ip1.unwrap()));
+        let ip6 = Source::new(IpAddr::from(ip2.unwrap()));
+        let ip7 = Destination::new(IpAddr::from(ip3.unwrap()));
+        let ip8 = Source::new(IpAddr::from(ip4.unwrap()));
+
+        assert_eq!(ip5.unwrap(), Ipv4Addr::UNSPECIFIED);
+        assert_eq!(ip6.unwrap(), Ipv4Addr::UNSPECIFIED);
+        assert_eq!(ip7.unwrap(), Ipv6Addr::UNSPECIFIED);
+        assert_eq!(ip8.unwrap(), Ipv6Addr::UNSPECIFIED);
+    }
+
+    #[test]
+    fn test_src_dst_socketaddr() {
+        let sa1 = Destination::new(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 42));
+        let sa2 = Source::new(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 42));
+        let sa3 = Destination::new(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 42, 0, 0));
+        let sa4 = Source::new(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 42, 0, 0));
+
+        let sa5 = Destination::new(SocketAddr::from(sa1.unwrap()));
+        let sa6 = Source::new(SocketAddr::from(sa2.unwrap()));
+        let sa7 = Destination::new(SocketAddr::from(sa3.unwrap()));
+        let sa8 = Source::new(SocketAddr::from(sa4.unwrap()));
+
+        assert_eq!(
+            (sa5.unwrap().ip(), sa5.unwrap().port()),
+            (Ipv4Addr::UNSPECIFIED.into(), 42)
+        );
+        assert_eq!(
+            (sa6.unwrap().ip(), sa6.unwrap().port()),
+            (Ipv4Addr::UNSPECIFIED.into(), 42)
+        );
+        assert_eq!(
+            (sa7.unwrap().ip(), sa7.unwrap().port()),
+            (Ipv6Addr::UNSPECIFIED.into(), 42)
+        );
+        assert_eq!(
+            (sa8.unwrap().ip(), sa8.unwrap().port()),
+            (Ipv6Addr::UNSPECIFIED.into(), 42)
+        );
+    }
+}

--- a/luomu-common/src/directed_addr.rs
+++ b/luomu-common/src/directed_addr.rs
@@ -1,5 +1,7 @@
+use std::ops::{Deref, DerefMut};
+
 /// A `Source` of any kind. For example an IP address.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Source<ADDR>(ADDR);
 
 impl<ADDR> Source<ADDR> {
@@ -19,8 +21,46 @@ impl<ADDR> Source<ADDR> {
     }
 }
 
+impl<ADDR> From<ADDR> for Source<ADDR> {
+    fn from(addr: ADDR) -> Self {
+        Self::new(addr)
+    }
+}
+
+impl<ADDR> From<Destination<ADDR>> for Source<ADDR> {
+    fn from(addr: Destination<ADDR>) -> Self {
+        addr.flip()
+    }
+}
+
+impl<ADDR> Deref for Source<ADDR> {
+    type Target = ADDR;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<ADDR> DerefMut for Source<ADDR> {
+    fn deref_mut(&mut self) -> &mut ADDR {
+        &mut self.0
+    }
+}
+
+impl<ADDR> AsRef<ADDR> for Source<ADDR> {
+    fn as_ref(&self) -> &ADDR {
+        &self.0
+    }
+}
+
+impl<ADDR> AsMut<ADDR> for Source<ADDR> {
+    fn as_mut(&mut self) -> &mut ADDR {
+        &mut self.0
+    }
+}
+
 /// A `Destination` of any kind. For example an IP address.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Destination<ADDR>(ADDR);
 
 impl<ADDR> Destination<ADDR> {
@@ -37,6 +77,44 @@ impl<ADDR> Destination<ADDR> {
     /// Returns the underlying value inside `Destination`.
     pub fn unwrap(self) -> ADDR {
         self.0
+    }
+}
+
+impl<ADDR> From<ADDR> for Destination<ADDR> {
+    fn from(addr: ADDR) -> Self {
+        Self::new(addr)
+    }
+}
+
+impl<ADDR> From<Source<ADDR>> for Destination<ADDR> {
+    fn from(addr: Source<ADDR>) -> Self {
+        addr.flip()
+    }
+}
+
+impl<ADDR> Deref for Destination<ADDR> {
+    type Target = ADDR;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<ADDR> DerefMut for Destination<ADDR> {
+    fn deref_mut(&mut self) -> &mut ADDR {
+        &mut self.0
+    }
+}
+
+impl<ADDR> AsRef<ADDR> for Destination<ADDR> {
+    fn as_ref(&self) -> &ADDR {
+        &self.0
+    }
+}
+
+impl<ADDR> AsMut<ADDR> for Destination<ADDR> {
+    fn as_mut(&mut self) -> &mut ADDR {
+        &mut self.0
     }
 }
 
@@ -102,5 +180,24 @@ mod tests {
             (sa8.unwrap().ip(), sa8.unwrap().port()),
             (Ipv6Addr::UNSPECIFIED.into(), 42)
         );
+    }
+
+    #[test]
+    fn test_deref() {
+        let a = Source::new(Ipv4Addr::UNSPECIFIED);
+        assert_eq!(*a, Ipv4Addr::UNSPECIFIED);
+        assert!(a.is_unspecified());
+
+        let mut b = Source::new(Ipv4Addr::UNSPECIFIED);
+        *b = Ipv4Addr::BROADCAST.into();
+        assert_eq!(*b, Ipv4Addr::BROADCAST);
+        assert!(b.is_broadcast());
+    }
+
+    #[test]
+    fn test_no_copy_type() {
+        let hello: &str = "Hello World!";
+        let a: Source<&str> = hello.into();
+        assert_eq!(*a, hello);
     }
 }

--- a/luomu-common/src/lib.rs
+++ b/luomu-common/src/lib.rs
@@ -10,7 +10,7 @@
 
 //! # luomu-common
 //!
-//! Common types and functions for (low) level network programming.
+//! Common types and functions for (low level) network programming.
 
 use std::fmt;
 
@@ -19,6 +19,12 @@ pub use address::Address;
 
 mod macaddr;
 pub use macaddr::MacAddr;
+
+mod directed_addr;
+pub use directed_addr::{Destination, Source};
+
+mod addr_pair;
+pub use addr_pair::{AddrPair, IPPair, MacPair, PortPair};
 
 /// Invalid address error
 #[derive(Debug)]


### PR DESCRIPTION
Many network protocols have pair of addresses of some kind. Ethernet frames have source and destination MAC addresses, IP has either IPv4 or IPv6 addresses and TCP and UDP protocols have source and destination port numbers. This trait and types supporting it make it simple to have single type containing both addresses and keeping the direction.