### PR TITLE
unblock pcap iterator

### DIFF
--- a/luomu-libpcap/examples/capture.rs
+++ b/luomu-libpcap/examples/capture.rs
@@ -13,31 +13,32 @@ fn main() -> Result<()> {
     pcap.set_filter("udp")?;
 
     let mut count = 0;
-    for packet in pcap.capture() {
-        let packet = packet.packet();
+    loop {
         let mut hex = String::new();
-        for (i, _) in packet.iter().enumerate() {
-            if i % 4 == 0 {
-                hex.push(' ');
+        for packet in pcap.capture() {
+            let packet = packet.packet();
+            for (i, _) in packet.iter().enumerate() {
+                if i % 4 == 0 {
+                    hex.push(' ');
+                }
+                if i % 32 == 0 {
+                    hex.push('\n');
+                }
+                hex.push_str(&format!("{:02x}", packet[i]));
             }
-            if i % 32 == 0 {
-                hex.push('\n');
-            }
-            hex.push_str(&format!("{:02x}", packet[i]));
-        }
-        count += 1;
-        println!("{}", hex);
-        if count % 100 == 0 && count != 0 {
-            if let Ok(stats) = pcap.stats() {
-                println!(
-                    "\nStats: received: {} packets, dropped: {} packets, dropped on interface {} packets",
-                    stats.packets_received(),
-                    stats.packets_dropped(),
-                    stats.packets_dropped_interface()
-                );
+            count += 1;
+            println!("{}", hex);
+            hex.clear();
+            if count % 100 == 0 && count != 0 {
+                if let Ok(stats) = pcap.stats() {
+                    println!(
+                        "\nStats: received: {} packets, dropped: {} packets, dropped on interface {} packets",
+                        stats.packets_received(),
+                        stats.packets_dropped(),
+                        stats.packets_dropped_interface()
+                    );
+                }
             }
         }
     }
-
-    Ok(())
 }

--- a/luomu-libpcap/src/lib.rs
+++ b/luomu-libpcap/src/lib.rs
@@ -356,19 +356,7 @@ impl<'p> Iterator for PcapIter<'p> {
     type Item = BorrowedPacket;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            match pcap_next_ex(self.pcap_t) {
-                Ok(p) => return Some(p),
-                Err(e) => match e {
-                    // pcap_next_ex() sometimes seems to return
-                    // "packet buffer expired" (whatever that means),
-                    // even if the immediate mode is set. Just retry in
-                    // this case.
-                    Error::Timeout => return None,
-                    _ => return None,
-                },
-            }
-        }
+        pcap_next_ex(self.pcap_t).ok()
     }
 }
 

--- a/luomu-libpcap/src/lib.rs
+++ b/luomu-libpcap/src/lib.rs
@@ -364,7 +364,7 @@ impl<'p> Iterator for PcapIter<'p> {
                     // "packet buffer expired" (whatever that means),
                     // even if the immediate mode is set. Just retry in
                     // this case.
-                    Error::Timeout => continue,
+                    Error::Timeout => return None,
                     _ => return None,
                 },
             }


### PR DESCRIPTION
In my opinion, the iterator should return None in the case of a timeout. With this, the iterator is no longer blocking and a consumer can decide themselves when to stop the loop. This is especially important if one would like to run the capture in a parallel thread and be able to stop that thread gracefully by notfiying it.

To make this more clear, some (pseudo-)code:

```rust
let (s,r) = mspc::channel();
let _ = thread::spawn(move || {
    let pcap Pcap::builder("lo").expect("").activate().expect("");
    let mut packets = Vec::new();
    loop {
         match pcap.capture().next() {
              None => {}
              Some(pkt) => {
                  packets.push(pkt);
              }
          };

          match r.try_recv() {
              Ok(_) | Err(TryRecvError::Disconnected) => {
                  // save packets to file
                  break;
              },
              Err(TryRecvError::Empty) => {},
          }
      }
}
thread::sleep(Duration::from_secs(10)); // do some important stuff, e.g. send packets to loopback
s.send(()); // if there are no more packets after the ten seconds, the thread will block in the iterator forever and never receive the message
```

Any thoughts on this?