### PR TITLE
Add crate containing wrapper for getifaddrs()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,10 @@ members = [
 	"luomu-libpcap",
 	"luomu-libpcap-sys",
 	"luomu-tpacketv3",
+	"luomu-getifaddrs",
 ]
 
 [workspace.package]
 license = "MIT"
 edition = "2021"
-rust-version = "1.70.0"  # MSRV
+rust-version = "1.70.0" # MSRV

--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
 # luomu-libpcap
 
-Safe and mostly sane Rust bindings for [libpcap](https://www.tcpdump.org/).
+Safe and mostly sane Rust bindings for [libpcap](https://www.tcpdump.org/) and
+some other network related functionalities.
 
-We are split in two different crates:
-  * `luomu-libpcap-sys` for unsafe Rust bindings generated directly from
-    `libpcap`.
-  * `luomu-libpcap` for safe and sane libpcap interface.
+## Lipcap bindings
+
+Libpacp bindings are split in two different crates:
+
+- `luomu-libpcap-sys` for unsafe Rust bindings generated directly from
+  `libpcap`.
+- `luomu-libpcap` for safe and sane libpcap interface.
 
 `luomu-libpcap` crate is split into two parts itself:
-  * `functions` module contains safe wrappers and sane return values for libpcap
-    functions.
-  * the root of the project contains `Pcap` struct et al. for more Rusty API to
-    interact with libpcap.
 
-You probably want to use the `Pcap` struct and other things from root of this
-crate.
+- `functions` module contains safe wrappers and sane return values for libpcap
+  functions.
+- the root of the project contains `Pcap` struct et al. for more Rusty API to
+  interact with libpcap.
 
-## Example
+### Example
 
 ```rust
 use luomu_libpcap::{Pcap, Result};
@@ -48,6 +50,21 @@ fn main() -> Result<()> {
     Ok(())
 }
 ```
+
+## Other crates
+
+Other crates, these do not require or use `libpcap`:
+
+- `luomu-tpacketv3` contains Rust bindings for capturing network traffic on
+  Linux with `AF_PACKET` sockets and
+  [tpcacket_v3](https://www.kernel.org/doc/Documentation/networking/packet_mmap.txt)
+- `luomu-getifaddrs` provides Rust bindings for `getiffaddrs()` to get network
+  interface addresses and statistics with
+- `luomu-common` contains utilities for working with IP Addresses, MAC addresses
+  and such.
+
+You probably want to use the `Pcap` struct and other things from root of this
+crate.
 
 ## License
 

--- a/luomu-getifaddrs/Cargo.toml
+++ b/luomu-getifaddrs/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "luomu-getifaddrs"
+version = "0.1.0"
+authors = ["Ossi Herrala <oherrala@iki.fi>"]
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+description = "Safe interface for getifaddrs()"
+homepage = "https://github.com/sensorfu/luomu-libpcap#readme"
+repository = "https://github.com/sensorfu/luomu-libpcap"
+documentation = "https://docs.rs/luomu-libpcap/"
+
+[dependencies]
+bitflags = "2"
+cfg-if = "1"
+libc = { version = "0.2", features = ["extra_traits"] }
+luomu-common = { path = "../luomu-common" }

--- a/luomu-getifaddrs/examples/interfaces.rs
+++ b/luomu-getifaddrs/examples/interfaces.rs
@@ -1,0 +1,11 @@
+fn main() -> std::io::Result<()> {
+    use luomu_getifaddrs::getifaddrs;
+
+    let ifaddrs = getifaddrs()?;
+
+    for ifaddr in ifaddrs {
+        println!("{:#?}", ifaddr.ifaddress())
+    }
+
+    Ok(())
+}

--- a/luomu-getifaddrs/examples/ipaddresses.rs
+++ b/luomu-getifaddrs/examples/ipaddresses.rs
@@ -1,0 +1,23 @@
+use std::{collections::HashMap, net::IpAddr};
+
+/// Prints IP Addresses for all interfaces found
+fn main() -> std::io::Result<()> {
+    let mut addresses: HashMap<String, Vec<IpAddr>> = HashMap::new();
+    for ifa in luomu_getifaddrs::getifaddrs()? {
+        if let Some(a) = ifa.addr().and_then(|a| a.as_ip()) {
+            let addrs = addresses.entry(ifa.name().to_owned()).or_default();
+            addrs.push(a);
+        }
+    }
+    for (name, addrs) in addresses {
+        let addrs_text = addrs
+            .iter()
+            .map(|a| a.to_string())
+            .collect::<Vec<String>>()
+            .join(", ");
+
+        println!("{name}: {addrs_text}")
+    }
+
+    Ok(())
+}

--- a/luomu-getifaddrs/examples/macaddresses.rs
+++ b/luomu-getifaddrs/examples/macaddresses.rs
@@ -1,0 +1,10 @@
+/// Prints Mac Addresses for all interfaces found
+fn main() -> std::io::Result<()> {
+    for ifa in luomu_getifaddrs::getifaddrs()? {
+        if let Some(a) = ifa.addr().and_then(|a| a.as_mac()) {
+            println!("{} {a}", ifa.name());
+        }
+    }
+
+    Ok(())
+}

--- a/luomu-getifaddrs/src/flags.rs
+++ b/luomu-getifaddrs/src/flags.rs
@@ -1,0 +1,49 @@
+use bitflags::bitflags;
+
+bitflags! {
+    /// Interface flags
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    pub struct Flags: libc::c_int {
+        const UP = libc::IFF_UP;
+        const BROADCAST = libc::IFF_BROADCAST;
+        const DEBUG = libc::IFF_DEBUG;
+        const LOOPBACK = libc::IFF_LOOPBACK;
+        const POINTOPOINT = libc::IFF_POINTOPOINT;
+        const RUNNING = libc::IFF_RUNNING;
+        const NOARP = libc::IFF_NOARP;
+        const PROMISC = libc::IFF_PROMISC;
+        const NOTRAILERS = libc::IFF_NOTRAILERS;
+        const ALLMULTI = libc::IFF_ALLMULTI;
+        const MULTICAST = libc::IFF_MULTICAST;
+
+        #[cfg(target_os = "macos")]
+        const OACTIVE = libc::IFF_OACTIVE;
+        #[cfg(target_os = "macos")]
+        const SIMPLEX = libc::IFF_SIMPLEX;
+        #[cfg(target_os = "macos")]
+        const LINK0 = libc::IFF_LINK0;
+        #[cfg(target_os = "macos")]
+        const LINK1 = libc::IFF_LINK1;
+        #[cfg(target_os = "macos")]
+        const LINK2 = libc::IFF_LINK2;
+        #[cfg(target_os = "macos")]
+        const ALTPHYS = libc::IFF_ALTPHYS;
+
+        #[cfg(target_os = "linux")]
+        const MASTER = libc::IFF_MASTER;
+        #[cfg(target_os = "linux")]
+        const SLAVE = libc::IFF_SLAVE;
+        #[cfg(target_os = "linux")]
+        const PORTSEL = libc::IFF_PORTSEL;
+        #[cfg(target_os = "linux")]
+        const AUTOMEDIA = libc::IFF_AUTOMEDIA;
+        #[cfg(target_os = "linux")]
+        const DYNAMIC = libc::IFF_DYNAMIC;
+        #[cfg(target_os = "linux")]
+        const LOWER_UP = libc::IFF_LOWER_UP;
+        #[cfg(target_os = "linux")]
+        const DORMANT = libc::IFF_DORMANT;
+        #[cfg(target_os = "linux")]
+        const ECHO = libc::IFF_ECHO;
+    }
+}

--- a/luomu-getifaddrs/src/lib.rs
+++ b/luomu-getifaddrs/src/lib.rs
@@ -1,0 +1,332 @@
+//! This module provides access for addresses, both IP and MAC, assigned
+//! for network interfaces as well as statistics for a interface.
+#![cfg(unix)]
+
+use std::ffi::CStr;
+use std::io;
+use std::mem::MaybeUninit;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+#[cfg(target_os = "macos")]
+use std::slice;
+
+mod flags;
+pub use flags::Flags;
+
+mod stats;
+use luomu_common::{Address, MacAddr};
+pub use stats::IfStats;
+
+/// Length of MAC address in bytes
+const MAC_ADDR_LEN: usize = 6;
+
+/// Returns a linked list describing the network interfaces of
+/// the local system.
+pub fn getifaddrs() -> io::Result<IfAddrs> {
+    let mut base_ptr = MaybeUninit::uninit();
+    let ret = unsafe { libc::getifaddrs(base_ptr.as_mut_ptr()) };
+    if ret != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let base_ptr = unsafe { base_ptr.assume_init() };
+    let ifaddrs = IfAddrs {
+        base_ptr,
+        curr_ptr: Some(base_ptr),
+    };
+    Ok(ifaddrs)
+}
+
+/// Provides access to list containing information about network interfaces.
+#[derive(Debug)]
+pub struct IfAddrs {
+    // Base pointer is used to free the whole linked list
+    base_ptr: *mut libc::ifaddrs,
+    // Current pointer points to current item in linked list
+    curr_ptr: Option<*mut libc::ifaddrs>,
+}
+
+impl IfAddrs {
+    /// Returns information about current list item or [None] if no more
+    /// interfaces are available.
+    const fn ifaddr(&self) -> Option<IfAddr> {
+        if let Some(ptr) = self.curr_ptr {
+            return Some(IfAddr { ptr });
+        }
+        None
+    }
+
+    /// Advance to next interface on the list.
+    fn next(&mut self) {
+        if let Some(curr_ptr) = self.curr_ptr.take() {
+            let next_ptr = unsafe { *curr_ptr }.ifa_next;
+            if !next_ptr.is_null() {
+                self.curr_ptr = Some(next_ptr);
+            }
+        }
+    }
+
+    /// Returns all IP addresses of network interface with given name.
+    ///
+    /// Returned [Iterator] yields no values if interface with given name
+    /// does not exist.
+    pub fn ip_addresses(self, interface: &str) -> impl Iterator<Item = IpAddr> + '_ {
+        self.into_iter()
+            .filter(move |ifa| ifa.name() == interface)
+            .filter_map(|ifa| ifa.addr().and_then(|a| a.as_ip()))
+    }
+
+    /// Returns MAC address of interface with given name
+    ///
+    /// Returns [None] if no interface with given name does not exist
+    pub fn mac_address(self, interface: &str) -> Option<MacAddr> {
+        // there should be only one MAC address for interface thus it is
+        // ok to return the first mac address we get for given interface
+        self.into_iter()
+            .filter(|ifa| ifa.name() == interface)
+            .find_map(|ifa| ifa.addr().and_then(|a| a.as_mac()))
+    }
+
+    /// Returns statistics for interface with given name
+    ///
+    /// Returns [None] if no interface with given name does not exist
+    pub fn if_stats(self, interface: &str) -> Option<stats::LinkStats> {
+        self.into_iter()
+            .filter(move |ifa| ifa.name() == interface)
+            .find_map(|ifa| ifa.data())
+    }
+}
+
+impl Drop for IfAddrs {
+    fn drop(&mut self) {
+        if !self.base_ptr.is_null() {
+            unsafe { libc::freeifaddrs(self.base_ptr) };
+        }
+    }
+}
+
+impl Iterator for IfAddrs {
+    type Item = IfAddr;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(ifaddr) = self.ifaddr() {
+            self.next();
+            return Some(ifaddr);
+        }
+        None
+    }
+}
+
+/// Returns address family value from [libc::sockaddr]
+const fn sa_get_family(sa: *const libc::sockaddr) -> i32 {
+    unsafe { *sa }.sa_family as libc::c_int
+}
+
+/// Returns given [libc::sockaddr] pointer as a pointer to [libc::sockaddr_in]
+const fn sa_as_sockaddr_in(sa: *const libc::sockaddr) -> libc::sockaddr_in {
+    unsafe { *(sa as *const libc::sockaddr_in) }
+}
+
+/// Returns given [libc::sockaddr] pointer as a pointer to [libc::sockaddr_in6]
+const fn sa_as_sockaddr_in6(sa: *const libc::sockaddr) -> libc::sockaddr_in6 {
+    unsafe { *(sa as *const libc::sockaddr_in6) }
+}
+
+#[cfg(target_os = "macos")]
+/// Returns given [libc::sockaddr] pointer as a pointer to [libc::sockaddr_dl]
+const fn sa_as_sockaddr_dl(sa: *const libc::sockaddr) -> libc::sockaddr_dl {
+    unsafe { *(sa as *const libc::sockaddr_dl) }
+}
+
+/// This struct provides access to information about network interface.
+pub struct IfAddr {
+    /// pointer for the interface data
+    ptr: *const libc::ifaddrs,
+}
+
+impl IfAddr {
+    /// Access the [libc::ifaddrs] this element points to
+    const fn ifa(&self) -> libc::ifaddrs {
+        unsafe { *(self.ptr) }
+    }
+
+    /// Returns collected information about this interface.
+    pub fn ifaddress(&self) -> IfAddress<'_> {
+        IfAddress {
+            name: self.name(),
+            flags: self.flags(),
+            addr: self.addr(),
+            netmask: self.netmask(),
+            dstaddr: self.dstaddr(),
+            data: self.data(),
+        }
+    }
+
+    /// Interface name
+    pub fn name(&self) -> &str {
+        unsafe { CStr::from_ptr(self.ifa().ifa_name) }
+            .to_str()
+            .expect("convert interface name to UTF-8")
+    }
+
+    /// Interface flags
+    pub const fn flags(&self) -> Flags {
+        Flags::from_bits_truncate(self.ifa().ifa_flags as i32)
+    }
+
+    /// Interface address
+    pub fn addr(&self) -> Option<Address> {
+        IfAddr::read_addr(self.ifa().ifa_addr)
+    }
+
+    /// Interface netmask
+    pub fn netmask(&self) -> Option<IpAddr> {
+        IfAddr::read_addr(self.ifa().ifa_netmask).and_then(|a| a.as_ip())
+    }
+
+    /// Destination address for Point-to-Point link
+    pub fn dstaddr(&self) -> Option<IpAddr> {
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "macos")] {
+                IfAddr::read_addr(self.ifa().ifa_dstaddr).and_then(|a| a.as_ip())
+            } else if #[cfg(target_os = "linux")] {
+                IfAddr::read_addr(self.ifa().ifa_ifu).and_then(|a|a.as_ip())
+            }
+        }
+    }
+
+    /// Returns link statistics data, if available.
+    pub fn data(&self) -> Option<stats::LinkStats> {
+        if self.ifa().ifa_addr.is_null() {
+            return None;
+        }
+
+        if self.ifa().ifa_data.is_null() {
+            return None;
+        }
+
+        let family = sa_get_family(self.ifa().ifa_addr);
+
+        #[cfg(target_os = "linux")]
+        if family == libc::AF_PACKET {
+            let ifa_data = self.ifa().ifa_data;
+            let link_stats = unsafe { &*(ifa_data as *const stats::LinkStats) }.clone();
+            return Some(link_stats);
+        }
+
+        #[cfg(target_os = "macos")]
+        if family == libc::AF_LINK {
+            let ifa_data = self.ifa().ifa_data;
+            let link_stats = *(unsafe { &*(ifa_data as *const stats::LinkStats) });
+            return Some(link_stats);
+        }
+
+        None
+    }
+
+    /// Reads address information from given socket address pointer.
+    ///
+    /// Address may contain IP address or Link address, the returned
+    /// [Addr] reflects which one was read. [None] is returned if no address
+    /// was available, or it could not be read.
+    fn read_addr(ifa_addr: *const libc::sockaddr) -> Option<Address> {
+        if ifa_addr.is_null() {
+            return None;
+        }
+
+        let family = sa_get_family(ifa_addr);
+
+        match family {
+            libc::AF_INET => {
+                let a: libc::sockaddr_in = sa_as_sockaddr_in(ifa_addr);
+                Some(Address::from(Ipv4Addr::from(u32::from_be(
+                    a.sin_addr.s_addr,
+                ))))
+            }
+            libc::AF_INET6 => {
+                let a: libc::sockaddr_in6 = sa_as_sockaddr_in6(ifa_addr);
+                Some(Address::from(Ipv6Addr::from(a.sin6_addr.s6_addr)))
+            }
+            #[cfg(target_os = "macos")]
+            libc::AF_LINK => {
+                // MAC address for this interface
+                let a: libc::sockaddr_dl = sa_as_sockaddr_dl(ifa_addr);
+                // length of the address
+                let a_len = usize::from(a.sdl_alen);
+                // length of the name
+                let n_len = usize::from(a.sdl_nlen);
+                // If seems that name is stored to sdl_data before the mac
+                // address of the interface. However, libc::sockaddr_dl::sdl_data has been
+                // defined to contain 12 bytes. Thus, if name of the interface
+                // is longer than 6 bytes (characters), we can not read the MAC
+                // address of that interface.
+                if a_len != MAC_ADDR_LEN || n_len + a_len > a.sdl_data.len() {
+                    return None;
+                }
+                // also, sdl_data has been defined as i8 for whatever reason,
+                // we need bytes for mac address, thus a bit of unsafery
+                let data = &a.sdl_data;
+                let sdl_data_as_u8: &[u8] =
+                    unsafe { slice::from_raw_parts(data.as_ptr() as *const u8, data.len()) };
+                let mut address = [0u8; MAC_ADDR_LEN];
+                // mac address stored after name
+                // You may want to look into LLADDR() macro somewhere on Mac OS headers
+                let offset = usize::from(a.sdl_nlen);
+                address[..MAC_ADDR_LEN]
+                    .copy_from_slice(&sdl_data_as_u8[offset..offset + MAC_ADDR_LEN]);
+                Some(Address::from(address))
+            }
+            #[cfg(target_os = "linux")]
+            libc::AF_PACKET => {
+                // Mac address of the interface
+                let a: libc::sockaddr_ll = unsafe { *(ifa_addr as *const libc::sockaddr_ll) };
+                let a_len = usize::from(a.sll_halen);
+                debug_assert!(a_len == MAC_ADDR_LEN);
+                if a_len != MAC_ADDR_LEN {
+                    return None;
+                }
+                let mut address = [0u8; MAC_ADDR_LEN];
+                address[..MAC_ADDR_LEN].copy_from_slice(&a.sll_addr[..MAC_ADDR_LEN]);
+                Some(Address::from(address))
+            }
+            _ => None,
+        }
+    }
+}
+
+/// A view into interface data
+#[derive(Debug, Hash)]
+pub struct IfAddress<'a> {
+    /// Interface name
+    pub name: &'a str,
+    /// Interface flags
+    pub flags: Flags,
+    /// Interface address
+    pub addr: Option<Address>,
+    /// Interface netmask
+    pub netmask: Option<IpAddr>,
+    /// P2P interface destination or interface broadcast address
+    pub dstaddr: Option<IpAddr>,
+    /// Address specific data
+    pub data: Option<stats::LinkStats>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use crate::getifaddrs;
+
+    #[test]
+    fn test_getifaddrs() -> io::Result<()> {
+        let _ifaddrs = getifaddrs()?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_getifaddrs_iterator() -> io::Result<()> {
+        let ifaddrs = getifaddrs()?;
+        for ifaddr in ifaddrs {
+            let _addrs = ifaddr.ifaddress();
+        }
+        Ok(())
+    }
+}

--- a/luomu-getifaddrs/src/stats.rs
+++ b/luomu-getifaddrs/src/stats.rs
@@ -1,0 +1,87 @@
+#[cfg(target_os = "linux")]
+pub use RtnlLinkStats as LinkStats;
+
+#[cfg(target_os = "macos")]
+pub use libc::if_data as LinkStats;
+
+/// Source: <https://www.kernel.org/doc/html/latest/networking/statistics.html#c.rtnl_link_stats64>
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Hash)]
+pub struct RtnlLinkStats {
+    pub rx_packets: u32,
+    pub tx_packets: u32,
+    pub rx_bytes: u32,
+    pub tx_bytes: u32,
+    pub rx_errors: u32,
+    pub tx_errors: u32,
+    pub rx_dropped: u32,
+    pub tx_dropped: u32,
+    pub multicast: u32,
+    pub collisions: u32,
+    pub rx_length_errors: u32,
+    pub rx_over_errors: u32,
+    pub rx_crc_errors: u32,
+    pub rx_frame_errors: u32,
+    pub rx_fifo_errors: u32,
+    pub rx_missed_errors: u32,
+    pub tx_aborted_errors: u32,
+    pub tx_carrier_errors: u32,
+    pub tx_fifo_errors: u32,
+    pub tx_heartbeat_errors: u32,
+    pub tx_window_errors: u32,
+    pub rx_compressed: u32,
+    pub tx_compressed: u32,
+    pub rx_nohandler: u32,
+}
+
+pub trait IfStats {
+    /// Received packets for interface
+    fn rx_packets(&self) -> usize;
+
+    /// Transmitted packets for interface
+    fn tx_packets(&self) -> usize;
+
+    /// Received bytes for interface
+    fn rx_bytes(&self) -> usize;
+
+    /// Transmitted bytes for interface
+    fn tx_bytes(&self) -> usize;
+}
+
+#[cfg(target_os = "macos")]
+impl IfStats for libc::if_data {
+    fn rx_packets(&self) -> usize {
+        self.ifi_ipackets as usize
+    }
+
+    fn tx_packets(&self) -> usize {
+        self.ifi_opackets as usize
+    }
+
+    fn rx_bytes(&self) -> usize {
+        self.ifi_ibytes as usize
+    }
+
+    fn tx_bytes(&self) -> usize {
+        self.ifi_obytes as usize
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl IfStats for RtnlLinkStats {
+    fn rx_packets(&self) -> usize {
+        self.rx_packets as usize
+    }
+
+    fn tx_packets(&self) -> usize {
+        self.tx_packets as usize
+    }
+
+    fn rx_bytes(&self) -> usize {
+        self.rx_bytes as usize
+    }
+
+    fn tx_bytes(&self) -> usize {
+        self.tx_bytes as usize
+    }
+}


### PR DESCRIPTION
`luomu-getifaddrs` provides wrappers for `getifaddrs()` providing ability to fetch addresses (IP, MAC) and some statistics for interfaces .

While at it, added also some information to main README