### PR TITLE
Convert some String/Vec<u8> into respective Boxes

### DIFF
--- a/luomu-libpcap/src/functions.rs
+++ b/luomu-libpcap/src/functions.rs
@@ -50,7 +50,7 @@ pub fn pcap_create(source: &str) -> Result<PcapT> {
 
     trace!("pcap_create({}) => {:p}", source, pcap_t);
     if pcap_t.is_null() {
-        return Err(Error::PcapError(errbuf.as_string()?));
+        errbuf.as_error()?;
     }
     Ok(PcapT {
         pcap_t,
@@ -72,7 +72,7 @@ pub fn pcap_open_offline<P: AsRef<Path>>(savefile: P) -> Result<PcapT> {
 
     trace!("pcap_open_offline({:?}) => {:p}", fname, pcap_t);
     if pcap_t.is_null() {
-        return Err(Error::PcapError(errbuf.as_string()?));
+        errbuf.as_error()?;
     }
     Ok(PcapT {
         pcap_t,
@@ -174,7 +174,7 @@ pub fn pcap_set_nonblock(pcap_t: &PcapT, nonblock: bool) -> Result<()> {
     let ret = unsafe { libpcap::pcap_setnonblock(pcap_t.pcap_t, arg, errbuf.as_mut_ptr()) };
     match ret {
         PCAP_SUCCESS => Ok(()),
-        PCAP_ERROR => Err(Error::PcapError(errbuf.as_string()?)),
+        PCAP_ERROR => errbuf.as_error(),
         n => Err(Error::PcapErrorCode(n)),
     }
 }
@@ -497,7 +497,7 @@ pub fn pcap_findalldevs() -> Result<PcapIfT> {
             trace!("pcap_findalldevs() => {:p}", pcap_if_t);
             Ok(PcapIfT { pcap_if_t })
         }
-        PCAP_ERROR => Err(Error::PcapError(errbuf.as_string()?)),
+        PCAP_ERROR => errbuf.as_error(),
         n => Err(Error::PcapErrorCode(n)),
     }
 }

--- a/luomu-libpcap/src/lib.rs
+++ b/luomu-libpcap/src/lib.rs
@@ -229,6 +229,11 @@ impl Errbuf {
         Ok(self.as_str()?.to_string())
     }
 
+    /// Return libcap's error as [Error] type.
+    fn as_error<T>(&self) -> Result<T> {
+        Err(Error::PcapError(self.as_string()?))
+    }
+
     fn as_mut_ptr<T>(&mut self) -> *mut T {
         self.0.as_mut_ptr() as *mut T
     }

--- a/luomu-libpcap/src/lib.rs
+++ b/luomu-libpcap/src/lib.rs
@@ -59,7 +59,7 @@ pub struct PcapT {
     pcap_t: *mut libpcap::pcap_t,
     #[allow(dead_code)]
     errbuf: Errbuf,
-    interface: Option<String>,
+    interface: Option<Box<str>>,
 }
 
 // I assume the pcap_t pointer is safe to move between threads, but it can only
@@ -73,7 +73,7 @@ impl PcapT {
     /// `get_interface` returns the interface name if known or "<unknown>".
     pub fn get_inteface(&self) -> String {
         if let Some(name) = &self.interface {
-            name.to_owned()
+            name.to_string()
         } else {
             String::from("<unknown>")
         }
@@ -546,7 +546,7 @@ impl PcapIfT {
         for interface in self.get_interfaces() {
             if interface.has_address(ip) {
                 log::trace!("find_interface_with_ip({}) = {:?}", ip, interface);
-                return Some(interface.name);
+                return Some(interface.name.into_string());
             }
         }
         None
@@ -565,9 +565,9 @@ impl Drop for PcapIfT {
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Interface {
     /// Devices name
-    pub name: String,
+    pub name: Box<str>,
     /// Devices description
-    pub description: Option<String>,
+    pub description: Option<Box<str>>,
     /// All addresses found from device
     pub addresses: BTreeSet<InterfaceAddress>,
     /// Flags set for device
@@ -592,7 +592,7 @@ impl Interface {
 
     /// True if interface is has name `name`
     pub fn has_name(&self, name: &str) -> bool {
-        self.name == name
+        self.name.as_ref() == name
     }
 
     /// Return MAC aka Ethernet address of the interface


### PR DESCRIPTION
Boxes are good because they consume less space and we don't need to change the size of these `Strings`/`Vec<u8>`s.