### PR TITLE
Add `{Source, Destination}::into_inner()`

### DIFF
--- a/luomu-common/src/addr_pair.rs
+++ b/luomu-common/src/addr_pair.rs
@@ -55,7 +55,7 @@ impl AddrPair<IpAddr> for IPPair {
     /// [IPPair::new_checked], [IPPair::new_v4] or [IPPair::new_v6] instead for
     /// safe versions.
     fn new(src: Source<IpAddr>, dst: Destination<IpAddr>) -> IPPair {
-        match (src.unwrap(), dst.unwrap()) {
+        match (src.into_inner(), dst.into_inner()) {
             (IpAddr::V4(src), IpAddr::V4(dst)) => {
                 IPPair::new_v4(Source::new(src), Destination::new(dst))
             }
@@ -72,16 +72,16 @@ impl AddrPair<IpAddr> for IPPair {
     /// Returns the source IP address from pair.
     fn source(&self) -> Source<IpAddr> {
         match self {
-            IPPair::V4 { src, .. } => Source::new(IpAddr::from(src.unwrap())),
-            IPPair::V6 { src, .. } => Source::new(IpAddr::from(src.unwrap())),
+            IPPair::V4 { src, .. } => Source::new(IpAddr::from(src.into_inner())),
+            IPPair::V6 { src, .. } => Source::new(IpAddr::from(src.into_inner())),
         }
     }
 
     /// Returns the destination IP address from pair.
     fn destination(&self) -> Destination<IpAddr> {
         match self {
-            IPPair::V4 { dst, .. } => Destination::new(IpAddr::from(dst.unwrap())),
-            IPPair::V6 { dst, .. } => Destination::new(IpAddr::from(dst.unwrap())),
+            IPPair::V4 { dst, .. } => Destination::new(IpAddr::from(dst.into_inner())),
+            IPPair::V6 { dst, .. } => Destination::new(IpAddr::from(dst.into_inner())),
         }
     }
 
@@ -124,7 +124,7 @@ impl IPPair {
     /// Creates [IPPair] for given source and destination addresses.
     /// None is returned if addresses are of different address families.
     pub fn new_checked(src: Source<IpAddr>, dst: Destination<IpAddr>) -> Option<IPPair> {
-        match (src.unwrap(), dst.unwrap()) {
+        match (src.into_inner(), dst.into_inner()) {
             (IpAddr::V4(s), IpAddr::V4(d)) => {
                 Some(IPPair::new_v4(Source::new(s), Destination::new(d)))
             }
@@ -376,8 +376,8 @@ mod tests {
 
         let ippair1 = IPPair::new_checked(Source::new(ip1), Destination::new(ip2)).unwrap();
         let ippair2 = ippair1.flip();
-        assert_eq!(ippair2.source().unwrap(), ip2);
-        assert_eq!(ippair2.destination().unwrap(), ip1);
+        assert_eq!(ippair2.source().into_inner(), ip2);
+        assert_eq!(ippair2.destination().into_inner(), ip1);
     }
 
     #[test]
@@ -387,8 +387,8 @@ mod tests {
 
         let ippair1 = IPPair::new_checked(Source::new(ip1), Destination::new(ip2)).unwrap();
         let ippair2 = ippair1.flip();
-        assert_eq!(ippair2.source().unwrap(), ip2);
-        assert_eq!(ippair2.destination().unwrap(), ip1);
+        assert_eq!(ippair2.source().into_inner(), ip2);
+        assert_eq!(ippair2.destination().into_inner(), ip1);
     }
 
     #[test]
@@ -423,8 +423,8 @@ mod tests {
 
         let ippair1 = IPPair::new_v4(Source::new(ip1), Destination::new(ip2));
         let ippair2 = ippair1.flip();
-        assert_eq!(ippair2.source().unwrap(), ip2);
-        assert_eq!(ippair2.destination().unwrap(), ip1);
+        assert_eq!(ippair2.source().into_inner(), ip2);
+        assert_eq!(ippair2.destination().into_inner(), ip1);
     }
 
     #[test]
@@ -434,8 +434,8 @@ mod tests {
 
         let ippair1 = IPPair::new_v6(Source::new(ip1), Destination::new(ip2));
         let ippair2 = ippair1.flip();
-        assert_eq!(ippair2.source().unwrap(), ip2);
-        assert_eq!(ippair2.destination().unwrap(), ip1);
+        assert_eq!(ippair2.source().into_inner(), ip2);
+        assert_eq!(ippair2.destination().into_inner(), ip1);
     }
 
     #[test]
@@ -452,7 +452,7 @@ mod tests {
         let (p1, p2) = (42, 12765);
         let port_pair = PortPair::new(Source::new(p1), Destination::new(p2));
         let flipped = port_pair.flip();
-        assert_eq!(p1, flipped.destination().unwrap());
-        assert_eq!(p2, flipped.source().unwrap());
+        assert_eq!(p1, flipped.destination().into_inner());
+        assert_eq!(p2, flipped.source().into_inner());
     }
 }

--- a/luomu-common/src/directed_addr.rs
+++ b/luomu-common/src/directed_addr.rs
@@ -25,7 +25,13 @@ impl<ADDR> Source<ADDR> {
     }
 
     /// Returns the underlying value inside `Source`.
+    #[deprecated(note = "unwrap() will be removed, use into_inner() instead")]
     pub fn unwrap(self) -> ADDR {
+        self.0
+    }
+
+    /// Returns the underlying value inside this `Source`
+    pub fn into_inner(self) -> ADDR {
         self.0
     }
 }
@@ -104,7 +110,13 @@ impl<ADDR> Destination<ADDR> {
     }
 
     /// Returns the underlying value inside `Destination`.
+    #[deprecated(note = "unwrap() will be removed, use into_inner() instead")]
     pub fn unwrap(self) -> ADDR {
+        self.0
+    }
+
+    /// Returns the underlying value inside this `Destination`
+    pub fn into_inner(self) -> ADDR {
         self.0
     }
 }

--- a/luomu-common/src/directed_addr.rs
+++ b/luomu-common/src/directed_addr.rs
@@ -13,7 +13,7 @@ impl<ADDR> Source<ADDR> {
 
     /// Make a [Destination] out from `Source`.
     pub fn flip(self) -> Destination<ADDR> {
-        Destination(self.unwrap())
+        Destination(self.into_inner())
     }
 
     /// Return new [Source] where function f has been applied to ADDR.
@@ -76,13 +76,13 @@ impl<ADDR> AsMut<ADDR> for Source<ADDR> {
 
 impl From<Source<Ipv4Addr>> for Source<IpAddr> {
     fn from(addr: Source<Ipv4Addr>) -> Self {
-        Source::new(IpAddr::V4(addr.unwrap()))
+        Source::new(IpAddr::V4(addr.into_inner()))
     }
 }
 
 impl From<Source<Ipv6Addr>> for Source<IpAddr> {
     fn from(addr: Source<Ipv6Addr>) -> Self {
-        Source::new(IpAddr::V6(addr.unwrap()))
+        Source::new(IpAddr::V6(addr.into_inner()))
     }
 }
 
@@ -98,7 +98,7 @@ impl<ADDR> Destination<ADDR> {
 
     /// Make a [Source] out from `Destination`.
     pub fn flip(self) -> Source<ADDR> {
-        Source(self.unwrap())
+        Source(self.into_inner())
     }
 
     /// Return new [Destination] where function f has been applied to ADDR.
@@ -161,13 +161,13 @@ impl<ADDR> AsMut<ADDR> for Destination<ADDR> {
 
 impl From<Destination<Ipv4Addr>> for Destination<IpAddr> {
     fn from(addr: Destination<Ipv4Addr>) -> Self {
-        Destination::new(IpAddr::V4(addr.unwrap()))
+        Destination::new(IpAddr::V4(addr.into_inner()))
     }
 }
 
 impl From<Destination<Ipv6Addr>> for Destination<IpAddr> {
     fn from(addr: Destination<Ipv6Addr>) -> Self {
-        Destination::new(IpAddr::V6(addr.unwrap()))
+        Destination::new(IpAddr::V6(addr.into_inner()))
     }
 }
 
@@ -183,7 +183,7 @@ mod tests {
         let i2 = i1.flip();
         let i3 = i2.flip();
 
-        assert_eq!(i2.unwrap(), 42);
+        assert_eq!(i2.into_inner(), 42);
         assert_eq!(i1, i3);
     }
 
@@ -194,15 +194,15 @@ mod tests {
         let ip3 = Destination::new(Ipv6Addr::UNSPECIFIED);
         let ip4 = Source::new(Ipv6Addr::UNSPECIFIED);
 
-        let ip5 = Destination::new(IpAddr::from(ip1.unwrap()));
-        let ip6 = Source::new(IpAddr::from(ip2.unwrap()));
-        let ip7 = Destination::new(IpAddr::from(ip3.unwrap()));
-        let ip8 = Source::new(IpAddr::from(ip4.unwrap()));
+        let ip5 = Destination::new(IpAddr::from(ip1.into_inner()));
+        let ip6 = Source::new(IpAddr::from(ip2.into_inner()));
+        let ip7 = Destination::new(IpAddr::from(ip3.into_inner()));
+        let ip8 = Source::new(IpAddr::from(ip4.into_inner()));
 
-        assert_eq!(ip5.unwrap(), Ipv4Addr::UNSPECIFIED);
-        assert_eq!(ip6.unwrap(), Ipv4Addr::UNSPECIFIED);
-        assert_eq!(ip7.unwrap(), Ipv6Addr::UNSPECIFIED);
-        assert_eq!(ip8.unwrap(), Ipv6Addr::UNSPECIFIED);
+        assert_eq!(ip5.into_inner(), Ipv4Addr::UNSPECIFIED);
+        assert_eq!(ip6.into_inner(), Ipv4Addr::UNSPECIFIED);
+        assert_eq!(ip7.into_inner(), Ipv6Addr::UNSPECIFIED);
+        assert_eq!(ip8.into_inner(), Ipv6Addr::UNSPECIFIED);
     }
 
     #[test]
@@ -212,25 +212,25 @@ mod tests {
         let sa3 = Destination::new(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 42, 0, 0));
         let sa4 = Source::new(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 42, 0, 0));
 
-        let sa5 = Destination::new(SocketAddr::from(sa1.unwrap()));
-        let sa6 = Source::new(SocketAddr::from(sa2.unwrap()));
-        let sa7 = Destination::new(SocketAddr::from(sa3.unwrap()));
-        let sa8 = Source::new(SocketAddr::from(sa4.unwrap()));
+        let sa5 = Destination::new(SocketAddr::from(sa1.into_inner()));
+        let sa6 = Source::new(SocketAddr::from(sa2.into_inner()));
+        let sa7 = Destination::new(SocketAddr::from(sa3.into_inner()));
+        let sa8 = Source::new(SocketAddr::from(sa4.into_inner()));
 
         assert_eq!(
-            (sa5.unwrap().ip(), sa5.unwrap().port()),
+            (sa5.into_inner().ip(), sa5.into_inner().port()),
             (Ipv4Addr::UNSPECIFIED.into(), 42)
         );
         assert_eq!(
-            (sa6.unwrap().ip(), sa6.unwrap().port()),
+            (sa6.into_inner().ip(), sa6.into_inner().port()),
             (Ipv4Addr::UNSPECIFIED.into(), 42)
         );
         assert_eq!(
-            (sa7.unwrap().ip(), sa7.unwrap().port()),
+            (sa7.into_inner().ip(), sa7.into_inner().port()),
             (Ipv6Addr::UNSPECIFIED.into(), 42)
         );
         assert_eq!(
-            (sa8.unwrap().ip(), sa8.unwrap().port()),
+            (sa8.into_inner().ip(), sa8.into_inner().port()),
             (Ipv6Addr::UNSPECIFIED.into(), 42)
         );
     }
@@ -258,11 +258,11 @@ mod tests {
     fn test_map() {
         let src_port: Source<u16> = Source::new(12765);
         let new_port = src_port.map(|p| p.wrapping_add(1));
-        assert_eq!(new_port.unwrap(), src_port.unwrap() + 1);
+        assert_eq!(new_port.into_inner(), src_port.into_inner() + 1);
 
         let dst_port: Destination<u16> = Destination::new(12765);
         let new_port = dst_port.map(|p| p.wrapping_add(2));
-        assert_eq!(new_port.unwrap(), src_port.unwrap() + 2);
+        assert_eq!(new_port.into_inner(), src_port.into_inner() + 2);
 
         let src_ip: Source<Ipv4Addr> = Source::new(Ipv4Addr::UNSPECIFIED);
         assert_eq!(


### PR DESCRIPTION
The naming of `unwrap()` method for `Source` and `Destination` is a bit unfortunate as `unwrap()` is almost like a reserved word. This leads into confusion in, for example, code reviews where `unwrap()` might be confused with a call which might lead to panic.

Thus, add `into_inner()` which does the same thing as `unwrap()` and is in line with the way this kind of methods are typically named.

Also, deprecate the `unwrap()` allowing us to remove it in the future.