### PR TITLE
Add serde serialization for MacAddr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ cc = "1"
 liblzma = { version = "0.4", features = ["static"] }
 tar = {version = "0.4", default-features = false }
 clap = { version = "4", features = [ "derive" ] }
+serde = { version = "1", features = ["derive"] }
 
 [workspace.lints.rust]
 # Lint groups

--- a/luomu-common/Cargo.toml
+++ b/luomu-common/Cargo.toml
@@ -15,7 +15,8 @@ repository.workspace = true
 default = []
 
 [dependencies]
-libc = { version = "0.2", optional = true }
+libc = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 quickcheck.workspace = true

--- a/luomu-common/src/macaddr.rs
+++ b/luomu-common/src/macaddr.rs
@@ -3,6 +3,9 @@ use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, de};
+
 use crate::{InvalidAddress, TagError};
 
 /// The MAC address portion of u64
@@ -286,6 +289,27 @@ impl fmt::Debug for MacAddr {
         } else {
             write!(f, "MacAddr({self})")
         }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for MacAddr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ::serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for MacAddr {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: &str = de::Deserialize::deserialize(deserializer)?;
+        Ok(Self(FromStr::from_str(s).map_err(de::Error::custom)?))
     }
 }
 


### PR DESCRIPTION
Adds `serde` feature to `luomu-common` and implements `Serialize`/`Deserialize` for `MacAddr`.